### PR TITLE
Update get_by_code to pass LsThing.

### DIFF
--- a/acasclient/interactions.py
+++ b/acasclient/interactions.py
@@ -27,7 +27,8 @@ INTERACTION_VERBS_DICT = {
     'comprises': 'is comprised of',
     'analyzes': 'is analyzed by',
     'is input structure for': 'has input structure',
-    'owns': 'is owned by'
+    'owns': 'is owned by',
+    'is compatible with': 'is compatible with',
 }
 
 

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -1841,7 +1841,7 @@ class SimpleLsThing(BaseModel):
         if not ls_kind:
             ls_kind = cls.ls_kind
         ls_thing = client.get_ls_thing(ls_type, ls_kind, code_name)
-        return cls(ls_thing=ls_thing)
+        return cls(ls_thing=LsThing.from_camel_dict(ls_thing))
 
     @classmethod
     def save_list(cls, client, models):

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -1840,8 +1840,8 @@ class SimpleLsThing(BaseModel):
             ls_type = cls.ls_type
         if not ls_kind:
             ls_kind = cls.ls_kind
-        ls_thing = client.get_ls_thing(ls_type, ls_kind, code_name)
-        return cls(ls_thing=LsThing.from_camel_dict(ls_thing))
+        camel_case_dict = client.get_ls_thing(ls_type, ls_kind, code_name)
+        return cls(ls_thing=LsThing.from_camel_dict(data=camel_case_dict))
 
     @classmethod
     def save_list(cls, client, models):


### PR DESCRIPTION
- Add `is compatible with` interaction ls_type.
- Updated `get_by_code` to create LsThing from camel cased dict keys and pass that in `ls_thing`
I am not sure about the output dict key case of [get_ls_thing](https://github.com/mcneilco/acasclient/blob/183596bb26a68bd36a71234acaae988a1766e10d/acasclient/acasclient.py#L776) but I checked that when we save it from [save](https://github.com/mcneilco/acasclient/blob/ef9e14300c1a2d1cf109b93aeea73a9c1ff713fb/acasclient/lsthing.py#L1180), we change it to camel case.