### PR TITLE
Fix 'make_ls_value' API

### DIFF
--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -301,7 +301,7 @@ def make_ls_value(value_cls, value_kind, val, recorded_by):
     if isinstance(val, FileValue):
         value = value_cls(ls_type="fileValue", ls_kind=value_kind, recorded_by=recorded_by,
                           file_value=val, unit_kind=unit_kind)
-    if isinstance(val, BlobValue):
+    elif isinstance(val, BlobValue):
         value = value_cls(
             ls_type="blobValue",
             ls_kind=value_kind,


### PR DESCRIPTION
`make_ls_value` should have `BlobValue` as an `elif` statement, else `FileValue` attribute would be overwritten with `str` logic since `FileValue` is a subclass of `str`.