### PR TITLE
Fixes #16 blob value comparison

### DIFF
--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -211,7 +211,7 @@ def is_equal_ls_value_simple_value(ls_value, val):
     elif isinstance(val, FileValue):
         return ls_value.file_value == val
     elif isinstance(val, BlobValue):
-        return ls_value.blob_value == BlobValue(val.value, val.comments)
+        return  BlobValue(ls_value.blob_value, ls_value.comments) == val
     elif isinstance(val, clob):
         return ls_value.clob_value == str(val)
     elif type(val) == str:

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -44,7 +44,24 @@ class TestLsThing(unittest.TestCase):
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
+    
+    # Helpers
+    def _get_path(self, file_name):
+        path = Path(__file__).resolve().parent\
+            .joinpath('test_acasclient', file_name)
+        return path
+    
+    def _get_bytes(self, file_path):
+        with open(file_path, "rb") as in_file:
+            file_bytes = in_file.read()
+        return file_bytes
+    
+    def _check_blob_equal(self, blob_value, orig_file_name, orig_bytes):
+        self.assertEqual(blob_value.comments, orig_file_name)
+        data = blob_value.download_data(self.client)
+        self.assertEqual(data, orig_bytes)
 
+    # Tests
     def test_000_simple_ls_thing_save(self):
         """Test saving simple ls thing."""
         name = str(uuid.uuid4())
@@ -83,9 +100,7 @@ class TestLsThing(unittest.TestCase):
         }
         newProject = Project(recorded_by=self.client.username, **meta_dict)
         newProject.save(self.client)
-        self.assertEqual(newProject.metadata['project metadata']['procedure document'].comments, file_name)
-        data = newProject.metadata['project metadata']['procedure document'].download_data(self.client)
-        self.assertEqual(data, file_bytes)
+        self._check_blob_equal(newProject.metadata['project metadata']['procedure document'], file_name, file_bytes)
 
         # Save with string path
         meta_dict = {
@@ -97,9 +112,7 @@ class TestLsThing(unittest.TestCase):
         }
         newProject = Project(recorded_by=self.client.username, **meta_dict)
         newProject.save(self.client)
-        self.assertEqual(newProject.metadata['project metadata']['procedure document'].comments, file_name)
-        data = newProject.metadata['project metadata']['procedure document'].download_data(self.client)
-        self.assertEqual(data, file_bytes)
+        self._check_blob_equal(newProject.metadata['project metadata']['procedure document'], file_name, file_bytes)
 
         # Write to a file by providing a full file path
         custom_file_name = "my.png"
@@ -169,27 +182,12 @@ class TestLsThing(unittest.TestCase):
     
     def test_002_update_blob_value(self):
         """Test saving simple ls thing with blob value, then updating the blobValue."""
-        # Helpers
-        def _get_path(file_name):
-            path = Path(__file__).resolve().parent\
-                .joinpath('test_acasclient', file_name)
-            return path
-        
-        def _get_bytes(file_path):
-            with open(file_path, "rb") as in_file:
-                file_bytes = in_file.read()
-            return file_bytes
-        
-        def _check_equal(blob_value, orig_file_name, orig_bytes):
-            self.assertEqual(blob_value.comments, orig_file_name)
-            data = blob_value.download_data(self.client)
-            self.assertEqual(data, orig_bytes)
         
         # Create a project with first blobValue
         name = str(uuid.uuid4())
         file_name = 'blob_test.png'
-        file_path = _get_path(file_name)
-        file_bytes = _get_bytes(file_path)
+        file_path = self._get_path(file_name)
+        file_bytes = self._get_bytes(file_path)
 
         # Save with Path path
         meta_dict = {
@@ -201,16 +199,16 @@ class TestLsThing(unittest.TestCase):
         }
         newProject = Project(recorded_by=self.client.username, **meta_dict)
         newProject.save(self.client)
-        _check_equal(newProject.metadata['project metadata']['procedure document'], file_name, file_bytes)
+        self._check_blob_equal(newProject.metadata['project metadata']['procedure document'], file_name, file_bytes)
         
         # Then update with a different file
         file_name = '1_1_Generic.xlsx'
-        file_path = _get_path(file_name)
-        file_bytes = _get_bytes(file_path)
+        file_path = self._get_path(file_name)
+        file_bytes = self._get_bytes(file_path)
         new_blob_val = BlobValue(file_path=file_path)
         newProject.metadata['project metadata']['procedure document'] = new_blob_val
         newProject.save(self.client)
-        _check_equal(newProject.metadata['project metadata']['procedure document'], file_name, file_bytes)
+        self._check_blob_equal(newProject.metadata['project metadata']['procedure document'], file_name, file_bytes)
 
 
 


### PR DESCRIPTION
BlobValue comparison in `is_equal_ls_value_simple_value` was backwards in that it was taking attributes from a BlobValue and re-casting them again as a BlobValue, rather than taking attributes from an LsValue and forming a BlobValue.

Added a test of updating a blobValue to confirm the fix.