### PR TITLE
ACAS-124: Update 'advanced_search_ls_things' API.

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -964,7 +964,8 @@ class client():
 
     def advanced_search_ls_things(self, ls_type, ls_kind, search_string,
                                   value_listings=[], codes_only=False,
-                                  max_results=1000):
+                                  max_results=1000, combine_terms_with_and=False,
+                                  format='stub'):
         """
         Query ACAS for deeply specified conditions
 
@@ -980,6 +981,8 @@ class client():
                     "valueKind": "librarian search status",
                     "operator": "="
                 }
+            combine_terms_with_and (bool): Whether to combine terms with 'and'
+            format (str): ACAS format to fetch data in
         Returns:
             if codes_only:
                 list of code_name strings
@@ -992,12 +995,14 @@ class client():
                 'maxResults': max_results,
                 'lsType': ls_type,
                 'lsKind': ls_kind,
-                'values': value_listings
+                'values': value_listings,
+                'combineTermsWithAnd': combine_terms_with_and,
             }
         }
         params = {}
         if codes_only:
-            params = {'format': 'codetable'}
+            format = 'codetable'
+        params['format'] = format
         resp = self.session.post('{}/api/advancedSearch/things/{}/{}'.
                                  format(self.url,
                                         ls_type,

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -1118,6 +1118,17 @@ class TestAcasclient(unittest.TestCase):
                                        max_results=1000)
         self.assertIn(codes[0], return_codes)
 
+        # Use 'codetable' data 'format'; 'codes_only' is False
+        results = self.client\
+            .advanced_search_ls_things('project', 'project', 'active',
+                                       value_listings=value_listings,
+                                       codes_only=False,
+                                       max_results=1000,
+                                       combine_terms_with_and=True,
+                                       format='codetable')
+        return_codes = [res['code'] for res in results]
+        self.assertIn(codes[0], return_codes)
+
     def test_033_get_all_lots(self):
         """Test get all lots request."""
 

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -1129,6 +1129,35 @@ class TestAcasclient(unittest.TestCase):
         return_codes = [res['code'] for res in results]
         self.assertIn(codes[0], return_codes)
 
+        # Test 'combine_terms_with_and'
+        value_listings[0]['value'] = 'active'
+        value_listings.append({
+            "stateType": "metadata",
+            "stateKind": "project metadata",
+            "valueType": "codeValue",
+            "valueKind": "project is restricted",
+            "operator": "=",
+            'value': 'true'  # Default is false
+        })
+
+        results = self.client\
+            .advanced_search_ls_things('project', 'project', None,
+                                       value_listings=value_listings,
+                                       codes_only=True,
+                                       max_results=1000,
+                                       combine_terms_with_and=False)
+        assert len(results) >= 3
+
+        results = self.client\
+            .advanced_search_ls_things('project', 'project', None,
+                                       value_listings=value_listings,
+                                       codes_only=True,
+                                       max_results=1000,
+                                       combine_terms_with_and=True)
+        assert len(results) == 0
+
+
+
     def test_033_get_all_lots(self):
         """Test get all lots request."""
 


### PR DESCRIPTION
Add `combine_terms_with_and` and `format` arguments to `advanced_search_ls_things` API.