### PR TITLE
'get_lskind_to_lsvalue' should consider 'unit_kind'

### DIFF
--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -178,6 +178,8 @@ def get_lsKind_to_lsvalue(ls_values_raw):
     lsKind_to_lsvalue = dict()
     for ls_value in ls_values:
         key = ls_value.ls_kind
+        if ls_value.unit_kind:
+            key = f'{key} ({ls_value.unit_kind})'
         if key in lsKind_to_lsvalue:
             lsKind_to_lsvalue[key].append(ls_value)
         else:
@@ -185,6 +187,8 @@ def get_lsKind_to_lsvalue(ls_values_raw):
 
     for ls_value in ls_values:
         key = ls_value.ls_kind
+        if ls_value.unit_kind:
+            key = f'{key} ({ls_value.unit_kind})'
         val = lsKind_to_lsvalue[key]
         if len(val) == 1:
             lsKind_to_lsvalue[key] = val[0]
@@ -595,12 +599,12 @@ class FileValue(object):
                 raise ValueError('file_path must be of str or <pathlib.PosixPath>. Provided file_path argument is of type {}'.format(type(value)))
         self.value = value
         self.comments = comments
-    
+
     def __eq__(self, other: object) -> bool:
         if other is None:
             return False
         return self.value == other.value and self.comments == other.comments
-    
+
     def download_to_disk(self, client, folder_path='./'):
         """Download file from ACAS and save to disk
 
@@ -619,7 +623,7 @@ class FileValue(object):
         if self.comments:
             acas_file["name"] = self.comments
         return str(client.write_file(acas_file, folder_path))
-    
+
     def as_dict(self) -> Dict[str, Any]:
         """
         Return a map of attribute name and attribute values stored on the
@@ -691,7 +695,7 @@ class BlobValue(object):
 
     def write_to_file(self, folder_path=None, file_name=None, full_file_path=None):
         """Write blob value to a file (requires that BlobValue.value has valid bytes).
-           This can be achieved but running <acasclient.lsthing.BlobValue.download_data> on the BlobValue 
+           This can be achieved but running <acasclient.lsthing.BlobValue.download_data> on the BlobValue
 
         :param folder_path: folder_path as an str or <pathlib.PosixPath>, defaults to None
         :type folder_path: Union[str, <pathlib.PosixPath>], optional

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -116,6 +116,22 @@ def parse_states_into_dict(ls_states_dict):
     return state_dict
 
 
+def _get_ls_value_key(ls_value):
+    """
+    Key to uniquely identify a `LsThingValue`.
+
+    :param ls_value: Ls thing value object.
+    :type ls_value: LsThingValue
+    :return: LsThingValue key.
+    :rtype: str
+    """
+
+    key = ls_value.ls_kind
+    if ls_value.unit_kind:
+        key = f'{key} ({ls_value.unit_kind})'
+    return key
+
+
 def parse_values_into_dict(ls_values):
     """Parse a list of LsValues into a dict of { value_kind: value }
     If there are multiple non-ignored LsValues with the same type, the value in the returned dict
@@ -129,9 +145,7 @@ def parse_values_into_dict(ls_values):
     values_dict = {}
     for value in ls_values:
         if not value.ignored and not value.deleted:
-            key = value.ls_kind
-            if value.unit_kind is not None and value.unit_kind != "":
-                key = f'{key} ({value.unit_kind})'
+            key = _get_ls_value_key(value)
             if value.ls_type == 'stringValue':
                 val = value.string_value
             elif value.ls_type == 'codeValue':
@@ -177,18 +191,14 @@ def get_lsKind_to_lsvalue(ls_values_raw):
     ls_values = [v for v in ls_values_raw if not v.ignored and not v.deleted]
     lsKind_to_lsvalue = dict()
     for ls_value in ls_values:
-        key = ls_value.ls_kind
-        if ls_value.unit_kind:
-            key = f'{key} ({ls_value.unit_kind})'
+        key = _get_ls_value_key(ls_value)
         if key in lsKind_to_lsvalue:
             lsKind_to_lsvalue[key].append(ls_value)
         else:
             lsKind_to_lsvalue[key] = [ls_value]
 
     for ls_value in ls_values:
-        key = ls_value.ls_kind
-        if ls_value.unit_kind:
-            key = f'{key} ({ls_value.unit_kind})'
+        key = _get_ls_value_key(ls_value)
         val = lsKind_to_lsvalue[key]
         if len(val) == 1:
             lsKind_to_lsvalue[key] = val[0]

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -3,13 +3,16 @@
 """Tests for `acasclient` package."""
 
 import os
-import unittest
-from acasclient import acasclient
-from acasclient.lsthing import SimpleLsThing, CodeValue, BlobValue, FileValue
-from pathlib import Path
 import tempfile
 import time
+import unittest
 import uuid
+from pathlib import Path
+
+from acasclient import acasclient
+from acasclient.lsthing import (BlobValue, CodeValue, FileValue, LsThingValue,
+                                SimpleLsThing, get_lsKind_to_lsvalue)
+
 # SETUP
 # "bob" user name registered
 # "PROJ-00000001" registered
@@ -49,23 +52,23 @@ class TestLsThing(unittest.TestCase):
         dummy_file = Path('dummy.pdf')
         if dummy_file.exists():
             os.remove(dummy_file)
-    
+
     # Helpers
     def _get_path(self, file_name):
         path = Path(__file__).resolve().parent\
             .joinpath('test_acasclient', file_name)
         return path
-    
+
     def _get_bytes(self, file_path):
         with open(file_path, "rb") as in_file:
             file_bytes = in_file.read()
         return file_bytes
-    
+
     def _check_blob_equal(self, blob_value, orig_file_name, orig_bytes):
         self.assertEqual(blob_value.comments, orig_file_name)
         data = blob_value.download_data(self.client)
         self.assertEqual(data, orig_bytes)
-    
+
     def _check_file(self, file_path, orig_file_name, orig_file_path):
         # Check file names match
         self.assertEqual(Path(file_path).name, orig_file_name)
@@ -148,9 +151,9 @@ class TestLsThing(unittest.TestCase):
         output_file = newProject.metadata['project metadata']['procedure document'].write_to_file(folder_path=str(self.tempdir))
         self.assertTrue(output_file.exists())
         self.assertEqual(output_file.name, file_name)
-        
 
-        # Write to a file by providing a folder and custom file name 
+
+        # Write to a file by providing a folder and custom file name
         output_file = newProject.metadata['project metadata']['procedure document'].write_to_file(folder_path=self.tempdir, file_name=custom_file_name)
         self.assertTrue(output_file.exists())
         self.assertEqual(output_file.name, custom_file_name)
@@ -162,7 +165,7 @@ class TestLsThing(unittest.TestCase):
             output_file = newProject.metadata['project metadata']['procedure document'].write_to_file(folder_path="GARBAGE")
         except ValueError as err:
             self.assertIn("does not exist", err.args[0])
-        
+
         # Make sure a bad path fails gracefully
         meta_dict = {
             "name": name,
@@ -192,10 +195,10 @@ class TestLsThing(unittest.TestCase):
             newProject = Project(recorded_by=self.client.username, **meta_dict)
         except ValueError as err:
             self.assertIn("not a file", err.args[0])
-    
+
     def test_002_update_blob_value(self):
         """Test saving simple ls thing with blob value, then updating the blobValue."""
-        
+
         # Create a project with first blobValue
         name = str(uuid.uuid4())
         file_name = 'blob_test.png'
@@ -213,7 +216,7 @@ class TestLsThing(unittest.TestCase):
         newProject = Project(recorded_by=self.client.username, **meta_dict)
         newProject.save(self.client)
         self._check_blob_equal(newProject.metadata['project metadata']['procedure document'], file_name, file_bytes)
-        
+
         # Then update with a different file
         file_name = '1_1_Generic.xlsx'
         file_path = self._get_path(file_name)
@@ -274,6 +277,32 @@ class TestLsThing(unittest.TestCase):
             output_file = fv.download_to_disk(self.client, folder_path="GARBAGE")
         except ValueError as err:
             self.assertIn("does not exist", err.args[0])
+
+    def test_004_get_lskind_to_ls_values(self):
+        """
+        Verify `get_lskind_to_lsvalue` adds the `unit_kind` if present to the
+        `lskind` value.
+        """
+
+        # No unit_kind in LsThingValue
+        lsthing_value = LsThingValue(
+            ls_type='foo',
+            ls_kind='bar',
+            numeric_value=4.5,
+        )
+        lskind_to_lsvalue = get_lsKind_to_lsvalue([lsthing_value])
+        assert len(lskind_to_lsvalue) == 1
+        assert 'bar' in lskind_to_lsvalue
+
+        # No unit_kind in LsThingValue
+        lsthing_value = LsThingValue(
+            ls_type='foo',
+            ls_kind='bar',
+            numeric_value=4.5,
+            unit_kind='baz')
+        lskind_to_lsvalue = get_lsKind_to_lsvalue([lsthing_value])
+        assert len(lskind_to_lsvalue) == 1
+        assert 'bar (baz)' in lskind_to_lsvalue
 
 
 class TestBlobValue(unittest.TestCase):


### PR DESCRIPTION
`get_lskind_to_lsvalue` should add the `unit_kind` if present to the `lskind` key else due to difference in logic between `get_lskind_to_lsvalue` and `parse_values_into_dict` we end up with duplicate values.

# Testing Done:
Added unit test.

This is all the work of @bffrost and I am just adding a test here so a big thanks to @bffrost for figuring out the bug and providing a fix.