### PR TITLE
Close open files/sockets and reduce default client logging to INFO

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -213,6 +213,7 @@ class TestAcasclient(unittest.TestCase):
     def tearDown(self):
         """Tear down test fixtures, if any."""
         shutil.rmtree(self.tempdir)
+        self.client.close()
 
     def test_000_creds_from_file(self):
         """Test creds from file."""
@@ -242,7 +243,8 @@ class TestAcasclient(unittest.TestCase):
     def test_002_client_initialization(self):
         """Test initializing client."""
         creds = acasclient.get_default_credentials()
-        acasclient.client(creds)
+        client = acasclient.client(creds)
+        client.close()
 
     def test_003_projects(self):
         """Test projects."""
@@ -769,7 +771,6 @@ class TestAcasclient(unittest.TestCase):
         self.assertIn('summary', search_results_export)
         search_results_export = self.client.\
             get_file(search_results_export['reportFilePath'])
-        print(search_results_export)
 
     def test_011_get_sdf_file_for_lots(self):
         """Test get sdf file for lots."""

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -75,6 +75,7 @@ class TestLsThing(unittest.TestCase):
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
+        self.client.close()
         files_to_delete = ['dummy.pdf', 'dummy2.pdf']
         for f in files_to_delete:
             file = Path(f)
@@ -707,6 +708,10 @@ class TestBlobValue(unittest.TestCase):
     def setUp(self) -> None:
         creds = acasclient.get_default_credentials()
         self.client = acasclient.client(creds)
+
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+        self.client.close()
 
     def test_as_dict(self):
         """


### PR DESCRIPTION
Fixes #38

Re ran tests which passed and output junk is greatly reduced:

```
bbolt@MacBook-Pro-2 oss % python -m unittest discover -s ./acasclient -p "test_*.py"
......................................................
----------------------------------------------------------------------
Ran 54 tests in 27.859s

OK
```