### PR TITLE
ACAS-235: Create acasclient utility for validating CodeValues

### DIFF
--- a/acasclient/ddict.py
+++ b/acasclient/ddict.py
@@ -8,6 +8,10 @@ logging.basicConfig(level=logging.INFO)
 
 
 class DDict(object):
+    """The DDict class is meant as a generic interface for any implementation of a Data Dictionary that
+    can be referenced by an ACAS CodeValue.
+    Any classes implementing this interface must implement the get_values() method.
+    """
 
     def __init__(self, code_type, code_kind, code_origin):
         self.code_type = code_type
@@ -25,6 +29,7 @@ class DDict(object):
 
 
 class ACASDDict(DDict):
+    """DDict implementation for built-in ACAS DDicts """
 
     CODE_ORIGIN = 'ACAS DDict'
 
@@ -45,6 +50,7 @@ class ACASDDict(DDict):
         return super(ACASDDict, self).check_value(value)
 
 class ACASLsThingDDict(DDict):
+    """DDict implementation for referencing ACAS LsThings"""
 
     CODE_ORIGIN = 'ACAS LsThing'
 

--- a/acasclient/ddict.py
+++ b/acasclient/ddict.py
@@ -10,7 +10,8 @@ logging.basicConfig(level=logging.INFO)
 class DDict(object):
     """The DDict class is meant as a generic interface for any implementation of a Data Dictionary that
     can be referenced by an ACAS CodeValue.
-    Any classes implementing this interface must implement the get_values() method.
+    Any classes implementing this interface must implement the update_valid_values() method.
+    The `update_valid_values` method must also be called before calling `check_value`
     """
 
     def __init__(self, code_type, code_kind, code_origin):
@@ -19,12 +20,14 @@ class DDict(object):
         self.code_origin = code_origin
         self.valid_values = None
 
-    def get_values(self):
+    def update_valid_values(self, client):
         raise NotImplementedError()
 
     @validation_result
     def check_value(self, value):
         """Check if the value is within `self.valid_values` for the DDict."""
+        if not self.valid_values:
+            raise ValueError('Valid values has not been populated. Call `update_valid_values` first.')
         if value not in self.valid_values:
             return False, f"Invalid 'code':'{value}' provided for the given 'code_type':'{self.code_type}' and 'code_kind':'{self.code_kind}'"
 
@@ -37,12 +40,12 @@ class ACASDDict(DDict):
     def __init__(self, code_type, code_kind):
         super(ACASDDict, self).__init__(code_type, code_kind, self.CODE_ORIGIN)
 
-    def get_values(self, client):
+    def update_valid_values(self, client):
         """Get the valid values for the DDict."""
         valid_codetables = client.get_ddict_values_by_type_and_kind(
             self.code_type, self.code_kind)
         self.valid_values = [val_dict['code'] for val_dict in valid_codetables]
-        if self.valid_values == []:
+        if not self.valid_values:
             raise ValueError(f"Invalid 'code_type':'{self.code_type}' or "
                     f"'code_kind':'{self.code_kind}' provided")
 
@@ -54,7 +57,7 @@ class ACASLsThingDDict(DDict):
     def __init__(self, thing_type, thing_kind):
         super(ACASLsThingDDict, self).__init__(thing_type, thing_kind, self.CODE_ORIGIN)
     
-    def get_values(self, client):
+    def update_valid_values(self, client):
         """Get the valid values for the DDict."""
         valid_codetables = client.get_ls_things_by_type_and_kind(self.code_type, self.code_kind, format='codetable')
         self.valid_values = [val_dict['code'] for val_dict in valid_codetables]

--- a/acasclient/ddict.py
+++ b/acasclient/ddict.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from typing import Any, Dict
 
 import logging
 

--- a/acasclient/ddict.py
+++ b/acasclient/ddict.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from .validation import validation_result
 
 import logging
 
@@ -21,10 +22,11 @@ class DDict(object):
     def get_values(self):
         raise NotImplementedError()
 
+    @validation_result
     def check_value(self, value):
+        """Check if the value is within `self.valid_values` for the DDict."""
         if value not in self.valid_values:
-            raise ValueError(f"Invalid 'code':'{value}' provided for the given "
-                f"'code_type':'{self.code_type}' and 'code_kind':'{self.code_kind}'")
+            return False, f"Invalid 'code':'{value}' provided for the given 'code_type':'{self.code_type}' and 'code_kind':'{self.code_kind}'"
 
 
 class ACASDDict(DDict):
@@ -36,6 +38,7 @@ class ACASDDict(DDict):
         super(ACASDDict, self).__init__(code_type, code_kind, self.CODE_ORIGIN)
 
     def get_values(self, client):
+        """Get the valid values for the DDict."""
         valid_codetables = client.get_ddict_values_by_type_and_kind(
             self.code_type, self.code_kind)
         self.valid_values = [val_dict['code'] for val_dict in valid_codetables]
@@ -52,5 +55,6 @@ class ACASLsThingDDict(DDict):
         super(ACASLsThingDDict, self).__init__(thing_type, thing_kind, self.CODE_ORIGIN)
     
     def get_values(self, client):
+        """Get the valid values for the DDict."""
         valid_codetables = client.get_ls_things_by_type_and_kind(self.code_type, self.code_kind, format='codetable')
         self.valid_values = [val_dict['code'] for val_dict in valid_codetables]

--- a/acasclient/ddict.py
+++ b/acasclient/ddict.py
@@ -13,16 +13,15 @@ class DDict(object):
         self.code_type = code_type
         self.code_kind = code_kind
         self.code_origin = code_origin
-        self.values = None
+        self.valid_values = None
 
     def get_values(self):
         raise NotImplementedError()
 
     def check_value(self, value):
-        if value in self.valid_values:
-            return True
-        else:
-            return False
+        if value not in self.valid_values:
+            raise ValueError(f"Invalid 'code':'{value}' provided for the given "
+                f"'code_type':'{self.code_type}' and 'code_kind':'{self.code_kind}'")
 
 
 class ACASDDict(DDict):
@@ -36,6 +35,14 @@ class ACASDDict(DDict):
         valid_codetables = client.get_ddict_values_by_type_and_kind(
             self.code_type, self.code_kind)
         self.valid_values = [val_dict['code'] for val_dict in valid_codetables]
+        if self.valid_values == []:
+            raise ValueError(f"Invalid 'code_type':'{self.code_type}' or "
+                    f"'code_kind':'{self.code_kind}' provided")
+    
+    def check_value(self, value, client):
+        if not self.valid_values:
+            self.get_values(client)
+        return super(ACASDDict, self).check_value(value)
 
 class ACASLsThingDDict(DDict):
 
@@ -48,3 +55,7 @@ class ACASLsThingDDict(DDict):
         valid_codetables = client.get_ls_things_by_type_and_kind(self.code_type, self.code_kind, format='codetable')
         self.valid_values = [val_dict['code'] for val_dict in valid_codetables]
     
+    def check_value(self, value, client):
+        if not self.valid_values:
+            self.get_values(client)
+        return super(ACASLsThingDDict, self).check_value(value)

--- a/acasclient/ddict.py
+++ b/acasclient/ddict.py
@@ -42,11 +42,6 @@ class ACASDDict(DDict):
         if self.valid_values == []:
             raise ValueError(f"Invalid 'code_type':'{self.code_type}' or "
                     f"'code_kind':'{self.code_kind}' provided")
-    
-    def check_value(self, value, client):
-        if not self.valid_values:
-            self.get_values(client)
-        return super(ACASDDict, self).check_value(value)
 
 class ACASLsThingDDict(DDict):
     """DDict implementation for referencing ACAS LsThings"""
@@ -59,8 +54,3 @@ class ACASLsThingDDict(DDict):
     def get_values(self, client):
         valid_codetables = client.get_ls_things_by_type_and_kind(self.code_type, self.code_kind, format='codetable')
         self.valid_values = [val_dict['code'] for val_dict in valid_codetables]
-    
-    def check_value(self, value, client):
-        if not self.valid_values:
-            self.get_values(client)
-        return super(ACASLsThingDDict, self).check_value(value)

--- a/acasclient/ddict.py
+++ b/acasclient/ddict.py
@@ -1,0 +1,50 @@
+from __future__ import unicode_literals
+from typing import Any, Dict
+
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class DDict(object):
+
+    def __init__(self, code_type, code_kind, code_origin):
+        self.code_type = code_type
+        self.code_kind = code_kind
+        self.code_origin = code_origin
+        self.values = None
+
+    def get_values(self):
+        raise NotImplementedError()
+
+    def check_value(self, value):
+        if value in self.valid_values:
+            return True
+        else:
+            return False
+
+
+class ACASDDict(DDict):
+
+    CODE_ORIGIN = 'ACAS DDict'
+
+    def __init__(self, code_type, code_kind):
+        super(ACASDDict, self).__init__(code_type, code_kind, self.CODE_ORIGIN)
+
+    def get_values(self, client):
+        valid_codetables = client.get_ddict_values_by_type_and_kind(
+            self.code_type, self.code_kind)
+        self.valid_values = [val_dict['code'] for val_dict in valid_codetables]
+
+class ACASLsThingDDict(DDict):
+
+    CODE_ORIGIN = 'ACAS LsThing'
+
+    def __init__(self, thing_type, thing_kind):
+        super(ACASLsThingDDict, self).__init__(thing_type, thing_kind, self.CODE_ORIGIN)
+    
+    def get_values(self, client):
+        valid_codetables = client.get_ls_things_by_type_and_kind(self.code_type, self.code_kind, format='codetable')
+        self.valid_values = [val_dict['code'] for val_dict in valid_codetables]
+    

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 from typing import Any, Dict
+
+from acasclient.ddict import DDict
 from .interactions import INTERACTION_VERBS_DICT, opposite
 
 import copy
@@ -945,7 +947,7 @@ class CodeValue(object):
     _fields = ['code_type', 'code_kind', 'code_origin', 'code']
 
     def __init__(self, code, code_type=None, code_kind=None,
-                 code_origin='ACAS DDict', client=None):
+                 code_origin='ACAS DDict', ddict=None):
         """Instantiate a new CodeValue
 
         :param code: value of this CodeValue, i.e. which DDictValue is being referenced
@@ -958,13 +960,17 @@ class CodeValue(object):
         :type code_origin: str
         """
         self.code = code
-        self.code_type = code_type
-        self.code_kind = code_kind
-        self.code_origin = code_origin
-
-        error_msg = self.validate(client)
-        if error_msg is not None:
-            raise ValueError(error_msg)
+        if ddict:
+            if isinstance(ddict, DDict):
+                self.code_type = ddict.code_type
+                self.code_kind = ddict.code_kind
+                self.code_origin = ddict.code_origin
+            else:
+                raise ValueError('ddict must be an instance of acasclient.ddict.DDict')
+        else:
+            self.code_type = code_type
+            self.code_kind = code_kind
+            self.code_origin = code_origin
 
     def __hash__(self):
         return hash(f'{self.code}-{self.code_type}-{self.code_kind}-'

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -974,28 +974,25 @@ class CodeValue(object):
             self.code_type = code_type
             self.code_kind = code_kind
             self.code_origin = code_origin
+            # Auto-recognize some code origin:
+            if self.code_origin.upper() == ACAS_DDICT:
+                self.ddict = ACASDDict(code_type, code_kind)
+            elif self.code_origin.upper() == ACAS_LSTHING:
+                self.ddict = ACASLsThingDDict(code_type, code_kind)
 
     def __hash__(self):
         return hash(f'{self.code}-{self.code_type}-{self.code_kind}-'
                     f'{self.code_origin}')
 
-    def validate(self, client):
-        """Validate that this CodeValue conforms to the saved list of possible DDictValues
+    def validate(self):
+        """Validate that this CodeValue conforms to the stored list of possible DDictValues in self.ddict
 
-
-        :param client: Authenticated acasclient.client instance to look up current DDictValues
-        :type client: acasclient.client
         :return: Error message, or None if valid
         :rtype: str | None
         """
-        if client is None:
-            return
         if self.ddict:
-            self.ddict.check_value(self.code, client)
+            self.ddict.check_value(self.code)
             return
-        elif self.code_origin.upper() == 'ACAS DDICT':
-            self.ddict = ACASDDict(code_type=self.code_type, code_kind=self.code_kind)
-            self.validate(client)
 
     def as_dict(self):
         return self.__dict__

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -991,8 +991,8 @@ class CodeValue(object):
     def validate(self):
         """Validate that this CodeValue conforms to the stored list of possible DDictValues in self.ddict
 
-        :return: Error message, or None if valid
-        :rtype: str | None
+        :return: ValidationResult indicating True / valid if code is valid, False / invalid otherwise
+        :rtype: ValidationResult
         """
         if self.ddict:
             return self.ddict.check_value(self.code)

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -960,6 +960,7 @@ class CodeValue(object):
         :type code_origin: str
         """
         self.code = code
+        self.ddict = ddict
         if ddict:
             if isinstance(ddict, DDict):
                 self.code_type = ddict.code_type
@@ -989,16 +990,21 @@ class CodeValue(object):
             return
         if self.code_origin.upper() != 'ACAS DDICT':
             return
-        valid_val_dicts = client.get_ddict_values_by_type_and_kind(
-            self.code_type, self.code_kind)
-        if valid_val_dicts == []:
-            raise ValueError(f"Invalid 'code_type':'{self.code_type}' or "
-                    f"'code_kind':'{self.code_kind}' provided")
-        if any([self.code == val_dict['code'] for val_dict in valid_val_dicts]):
-            return
+        else:
+            if self.ddict:
+                self.ddict.check_value(self.code, client)
+                return
+            else:
+                valid_val_dicts = client.get_ddict_values_by_type_and_kind(
+                    self.code_type, self.code_kind)
+                if valid_val_dicts == []:
+                    raise ValueError(f"Invalid 'code_type':'{self.code_type}' or "
+                            f"'code_kind':'{self.code_kind}' provided")
+                if any([self.code == val_dict['code'] for val_dict in valid_val_dicts]):
+                    return
 
-        raise ValueError(f"Invalid 'code':'{self.code}' provided for the given "
-                f"'code_type':'{self.code_type}' and 'code_kind':'{self.code_kind}'")
+                raise ValueError(f"Invalid 'code':'{self.code}' provided for the given "
+                        f"'code_type':'{self.code_type}' and 'code_kind':'{self.code_kind}'")
 
     def as_dict(self):
         return self.__dict__

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from typing import Any, Dict
 
-from acasclient.ddict import DDict
+from acasclient.ddict import ACASDDict, DDict
 from .interactions import INTERACTION_VERBS_DICT, opposite
 
 import copy
@@ -988,23 +988,12 @@ class CodeValue(object):
         """
         if client is None:
             return
-        if self.code_origin.upper() != 'ACAS DDICT':
+        if self.ddict:
+            self.ddict.check_value(self.code, client)
             return
-        else:
-            if self.ddict:
-                self.ddict.check_value(self.code, client)
-                return
-            else:
-                valid_val_dicts = client.get_ddict_values_by_type_and_kind(
-                    self.code_type, self.code_kind)
-                if valid_val_dicts == []:
-                    raise ValueError(f"Invalid 'code_type':'{self.code_type}' or "
-                            f"'code_kind':'{self.code_kind}' provided")
-                if any([self.code == val_dict['code'] for val_dict in valid_val_dicts]):
-                    return
-
-                raise ValueError(f"Invalid 'code':'{self.code}' provided for the given "
-                        f"'code_type':'{self.code_type}' and 'code_kind':'{self.code_kind}'")
+        elif self.code_origin.upper() == 'ACAS DDICT':
+            self.ddict = ACASDDict(code_type=self.code_type, code_kind=self.code_kind)
+            self.validate(client)
 
     def as_dict(self):
         return self.__dict__

--- a/acasclient/validation.py
+++ b/acasclient/validation.py
@@ -1,0 +1,89 @@
+import decorator
+from typing import List
+
+# Author: Anand Kumar
+
+################################################################################
+# Validation Result
+################################################################################
+
+
+class ValidationResult(object):
+    """
+    Class stores the validation results data. Each validation result stores
+     an optional list of messages.
+    Usage::
+
+            messages = ['Invalid file type', 'Multiple structures found']
+            val_res = ValidationResult(is_valid=True, messages=messages)
+
+            if not val_res:
+                print('\n'.join(val_res.get_messages()))
+
+    """
+
+    def __init__(self, is_valid: bool, messages: List[str] = None):
+        self._is_valid = is_valid
+        self._messages = messages or []
+
+    def __bool__(self) -> bool:
+        return self._is_valid
+
+    def __str__(self) -> str:
+        messages = '\n'.join(self._messages)
+        if self._is_valid and messages == '':
+            return 'VALID'
+        elif self._is_valid:
+            return 'VALID(Warnings): ' + messages
+        elif messages == '':
+            return 'INVALID'
+        else:
+            return 'INVALID(Errors): ' + messages
+
+    def __repr__(self) -> str:
+        return str(repr)
+
+    def __add__(self, other):
+        is_valid = self._is_valid and other._is_valid
+        messages = self._messages + other._messages
+        return ValidationResult(is_valid=is_valid, messages=messages)
+
+    def get_messages(self) -> List[str]:
+        return self._messages
+
+
+@decorator.decorator
+def validation_result(func, *args, **kwargs):
+    """
+    Encapsulate `func` returned values inside `ValidationResult`.
+
+    :return: Validation result.
+    :rtype: ValidationResult
+    :raises TypeError: If `func` doesn't return a bool or a tuple or
+            ValidationResult.
+    """
+
+    result = func(*args, **kwargs)
+
+    if result is None:
+        result = True
+
+    if isinstance(result, bool):
+        return ValidationResult(is_valid=result)
+    elif isinstance(result, tuple):
+        is_valid = result[0]
+        messages = []
+        if len(result) > 1:
+            _messages = result[1]
+            if isinstance(_messages, list):
+                messages = _messages
+            elif isinstance(_messages, str):
+                messages = [_messages]
+            else:
+                raise TypeError("Expected a tuple of a boolean and "
+                                f"list/str, got '{_messages}'")
+        return ValidationResult(is_valid=is_valid, messages=messages)
+    elif isinstance(result, ValidationResult):
+        return result
+
+    raise TypeError(f"Expected bool or tuple return values, got '{result}'")

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==22.0.4
+pip==19.2.3
 bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0
@@ -7,5 +7,4 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-pandas==1.4.1
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==19.2.3
+pip==22.0.4
 bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0
@@ -7,4 +7,5 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
+pandas==1.4.1
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['requests', 'pandas', 'six']
+requirements = ['requests', 'pandas', 'six', 'decorator']
 
 setup_requirements = [ ]
 

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -740,10 +740,10 @@ class TestLsThing(unittest.TestCase):
         except ValueError as e:
             error = e
         self.assertEqual(str(error), f"Invalid 'code':'{status_1}' provided for the given 'code_type':'{PROJECT}' and 'code_kind':'{STATUS}'")
-        # Now test timing of one-by-one validation with 1000 projects versus doing it in bulk
-        # Create 100 valid projects
+        # Now test timing of one-by-one validation with 20 projects versus doing it in bulk
+        # Create 20 valid projects
         meta_dict[STATUS_KEY] = ACTIVE
-        projects = [Project(recorded_by=self.client.username, **meta_dict) for i in range(100)]
+        projects = [Project(recorded_by=self.client.username, **meta_dict) for i in range(20)]
         single_start = datetime.now()
         for proj in projects:
             proj.validate(self.client)

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from acasclient import acasclient
 from acasclient.lsthing import (BlobValue, CodeValue, FileValue, LsThingValue,
                                 SimpleLsThing, get_lsKind_to_lsvalue)
+# from acasclient.ddict import ACASDDict
 
 # SETUP
 # "bob" user name registered
@@ -26,6 +27,7 @@ PROJECT_ALIAS = 'project alias'
 STATUS = 'status'
 PROJECT_STATUS = 'project status'
 PROCEDURE_DOCUMENT = 'procedure document'
+BOOLEAN = 'boolean'
 IS_RESTRICTED = 'is restricted'
 RESTRICTED = 'restricted'
 PDF_DOCUMENT = 'pdf document'
@@ -37,6 +39,8 @@ START_DATE_KEY = 'start_date'
 DESCRIPTION_KEY = 'description'
 PDF_DOCUMENT_KEY = 'pdf_document'
 PROCEDURE_DOCUMENT_KEY = 'procedure_document'
+ACTIVE = 'active'
+INACTIVE = 'inactive'
 
 FWD_ITX = 'relates to'
 BACK_ITX = 'is related to'
@@ -47,16 +51,18 @@ class Project(SimpleLsThing):
     ls_kind = PROJECT
     preferred_label_kind = PROJECT_NAME
 
+    # STATUS_DDICT = ACASDDict(PROJECT, STATUS)
+    # RESTRICTED_DDICT = ACASDDict(PROJECT, RESTRICTED)
 
     def __init__(self, name=None, alias=None, start_date=None, description=None, status=None, is_restricted=True, procedure_document=None, pdf_document=None, recorded_by=None,
-                 ls_thing=None, client=None):
+                 ls_thing=None):
         names = {PROJECT_NAME: name, PROJECT_ALIAS: alias}
         metadata = {
             PROJECT_METADATA: {
                 START_DATE: start_date,
                 DESCRIPTION_KEY: description,
-                PROJECT_STATUS: CodeValue(status, PROJECT, STATUS, ACAS_DDICT, client=client),
-                IS_RESTRICTED: CodeValue(str(is_restricted).lower(), PROJECT, RESTRICTED, ACAS_DDICT, client=client),
+                PROJECT_STATUS: CodeValue(status, PROJECT, STATUS, ACAS_DDICT),
+                IS_RESTRICTED: CodeValue(str(is_restricted).lower(), BOOLEAN, BOOLEAN, ACAS_DDICT),
                 PROCEDURE_DOCUMENT: BlobValue(file_path=procedure_document),
                 PDF_DOCUMENT: FileValue(file_path=pdf_document)
             }
@@ -114,7 +120,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now()
         }
         newProject = Project(recorded_by=self.client.username, **meta_dict)
@@ -140,7 +146,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
             PROCEDURE_DOCUMENT_KEY: blob_test_path
         }
@@ -152,7 +158,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
             PROCEDURE_DOCUMENT_KEY: str(blob_test_path)
         }
@@ -199,7 +205,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
             PROCEDURE_DOCUMENT_KEY: "SOMEGARBAGEPATH"
         }
@@ -214,7 +220,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
             PROCEDURE_DOCUMENT_KEY: self.tempdir
         }
@@ -238,7 +244,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
             PROCEDURE_DOCUMENT_KEY: file_path
         }
@@ -269,7 +275,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
             PDF_DOCUMENT_KEY: file_test_path
         }
@@ -284,7 +290,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
             PDF_DOCUMENT_KEY: str(file_test_path)
         }
@@ -299,7 +305,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
         }
         newProject = Project(recorded_by=self.client.username, **meta_dict)
@@ -316,7 +322,7 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now(),
         }
         newProject = Project(recorded_by=self.client.username, **meta_dict)
@@ -381,14 +387,14 @@ class TestLsThing(unittest.TestCase):
         meta_dict = {
             NAME_KEY: name,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now()
         }
         name_2 = str(uuid.uuid4())
         meta_dict_2 = {
             NAME_KEY: name_2,
             IS_RESTRICTED_KEY: True,
-            STATUS_KEY: "active",
+            STATUS_KEY: ACTIVE,
             START_DATE_KEY: datetime.now()
         }
         proj_1 = Project(recorded_by=self.client.username, **meta_dict)
@@ -570,7 +576,8 @@ class TestLsThing(unittest.TestCase):
         }
 
         proj_1 = Project(recorded_by=self.client.username, **meta_dict)
-        proj_1.save(self.client)
+        # skip CodeValue validation since this is not a valid status
+        proj_1.save(self.client, skip_validation=True)
 
         # Create project 2
         name_2 = str(uuid.uuid4())
@@ -584,12 +591,14 @@ class TestLsThing(unittest.TestCase):
             DESCRIPTION_KEY: desc_2
         }
         proj_2 = Project(recorded_by=self.client.username, **meta_dict_2)
-        proj_2.save(self.client)
+        # skip CodeValue validation since this is not a valid status
+        proj_2.save(self.client, skip_validation=True)
 
         # Add interactions between projects
         proj_1.add_link(FWD_ITX, proj_2, recorded_by=self.client.username)
         assert len(proj_1.links) == 1
-        proj_1.save(self.client)
+        # skip CodeValue validation since this is not a valid status
+        proj_1.save(self.client, skip_validation=True)
        
         # Run advanced search by interaction w/value matching on the interaction thing
         # Forward interaction query w/interaction thing values
@@ -716,11 +725,34 @@ class TestLsThing(unittest.TestCase):
             START_DATE_KEY: datetime.now(),
             DESCRIPTION_KEY: desc_1
         }
-
+        error = None
         try:
-            proj_1 = Project(recorded_by=self.client.username, client=self.client, **meta_dict)
+            proj_1 = Project(recorded_by=self.client.username, **meta_dict)
+            proj_1.validate(self.client)
         except ValueError as e:
-            assert str(e) == f"Invalid 'code':'{status_1}' provided for the given 'code_type':'{PROJECT}' and 'code_kind':'{STATUS}'"
+            error = e
+        self.assertEqual(str(error), f"Invalid 'code':'{status_1}' provided for the given 'code_type':'{PROJECT}' and 'code_kind':'{STATUS}'")
+    
+    # def test_009_validate_ddicts(self):
+    #     # Create project 1
+    #     name = str(uuid.uuid4())
+    #     status_1 = str(uuid.uuid4())
+    #     desc_1 = str(uuid.uuid4())
+    #     meta_dict = {
+    #         NAME_KEY: name,
+    #         IS_RESTRICTED_KEY: True,
+    #         STATUS_KEY: status_1,
+    #         START_DATE_KEY: datetime.now(),
+    #         DESCRIPTION_KEY: desc_1
+    #     }
+
+    #     proj_1 = Project(recorded_by=self.client.username, **meta_dict)
+    #     valid, errors = proj_1.validate_ddicts()
+    #     assert not valid
+    #     assert len(errors) == 1
+    #     # TODO decide if this is the final form
+    #     self.assertEqual(errors[0]["message"], f"No code values found for codeType: {PROJECT} and codeKind: {RESTRICTED}")
+
 
 class TestBlobValue(unittest.TestCase):
 


### PR DESCRIPTION
## Description
I set out to make a utility that would validate that the codes in CodeValues are actually valid, i.e. they show up in the appropriate ACAS DDict. I quickly found that I'd implemented an early version of this, but it relied on an acasclient session being passed in at the time a CodeValue was instantiated, which basically never happens.

I added some unit tests, then started refactoring:
- *Big change*: Added CodeValue validation into a new `SimpleLsThing.validate` function that now happens as part of `save` unless explicitly opted-out.
- Created a new "DDict" generic interface, with implementations for ACAS DDicts and ACAS LsThing references. These are meant as a place to store fetching and checking logic for each `codeOrigin`.
- I then refactored the existing CodeValue validation logic to instead always go through DDict

## Related Issue
#42 

## How Has This Been Tested?
I've run the LsThing tests locally and they pass. I'm seeing some failures with the ACASClient unit tests that I'm not sure are related to my changes, and might be peculiar to my dev environment.