### PR TITLE
Update acasclient to handle errors & warnings separately

### DIFF
--- a/acasclient/__init__.py
+++ b/acasclient/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Brian Bolt"""
 __email__ = 'brian.bolt@boltengineered.com'
-__version__ = '0.1.32'
+__version__ = '0.1.33'

--- a/acasclient/validation.py
+++ b/acasclient/validation.py
@@ -12,7 +12,7 @@ from typing import List
 class ValidationResult(object):
     """
     Class stores the validation results data. Each validation result stores
-     an optional list of messages.
+    an optional list of errors and warnings.
     Usage::
 
             messages = ['Invalid file type', 'Multiple structures found']
@@ -23,34 +23,48 @@ class ValidationResult(object):
 
     """
 
-    def __init__(self, is_valid: bool, messages: List[str] = None):
+    def __init__(self, is_valid: bool, messages: List[str] = None, errors: List[str] = None, warnings: List[str] = None):
         self._is_valid = is_valid
-        self._messages = messages or []
+        self._errors = errors or []
+        self._warnings = warnings or []
+        # For simple messages, classify them as errors or warnings based on the validity of the result
+        if messages:
+            if is_valid:
+                self._warnings += messages
+            else:
+                self._errors += messages
+        # Check we are not in the invalid state of "valid" with errors
+        if is_valid and self._errors:
+            raise ValueError("ValidationResult cannot be valid and contain error messages")
 
     def __bool__(self) -> bool:
         return self._is_valid
 
     def __str__(self) -> str:
-        messages = '\n'.join(self._messages)
-        if self._is_valid and messages == '':
-            return 'VALID'
-        elif self._is_valid:
-            return 'VALID(Warnings): ' + messages
-        elif messages == '':
-            return 'INVALID'
-        else:
-            return 'INVALID(Errors): ' + messages
+        res = 'VALID' if self._is_valid else 'INVALID'
+        if self._errors:
+            res += '\nERRORS:\n' + '\n'.join(self._errors)
+        if self._warnings:
+            res += '\nWARNINGS:\n' + '\n'.join(self._warnings)
+        return res
 
     def __repr__(self) -> str:
         return str(repr)
 
     def __add__(self, other):
         is_valid = self._is_valid and other._is_valid
-        messages = self._messages + other._messages
-        return ValidationResult(is_valid=is_valid, messages=messages)
+        errors = self._errors + other._errors
+        warnings = self._warnings + other._warnings
+        return ValidationResult(is_valid=is_valid, errors=errors, warnings=warnings)
 
     def get_messages(self) -> List[str]:
-        return self._messages
+        return self._errors + self._warnings
+    
+    def get_errors(self) -> List[str]:
+        return self._errors
+    
+    def get_warnings(self) -> List[str]:
+        return self._warnings
 
 
 @decorator.decorator
@@ -89,6 +103,28 @@ def validation_result(func, *args, **kwargs):
 
     raise TypeError(f"Expected bool or tuple return values, got '{result}'")
 
+
+def _dedupe_messages(messages: List[str]) -> List[str]:
+    """
+    Deduplicate messages and count occurrences.
+
+    :param messages: list of messages
+    :type messages: list
+
+    :return: list of deduplicated messages
+    :rtype: list
+    """
+    messages_dict = defaultdict(int)
+    for msg in messages:
+        messages_dict[msg] += 1
+    deduped_messages = []
+    for msg, count in messages_dict.items():
+        if count > 1:
+            deduped_messages.append(f'{count} occurrences of: {msg}')
+        else:
+            deduped_messages.append(msg)
+    return deduped_messages
+
 def get_validation_response(validation_result, ls_thing=None, commit=False, transaction_id=-1):
     """
     :param validation_result: validation result object
@@ -106,32 +142,20 @@ def get_validation_response(validation_result, ls_thing=None, commit=False, tran
     :return: validation response for the given result
     :rtype: dict
     """
-    # TODO: For now lets just categorise all messages with the same errorLevel.
-    has_errors = not bool(validation_result)
-    has_warnings = not has_errors and len(validation_result.get_messages()) > 0
-    if has_errors:
-        error_level = 'error'
-    elif has_warnings:
-        error_level = 'warning'
-    else:
-        error_level = ''
+    has_errors = len(validation_result.get_errors()) > 0
+    has_warnings = len(validation_result.get_warnings()) > 0
     
-    # Deduplicate error messages and count occurrences
-    messages = defaultdict(int)
-    for msg in validation_result.get_messages():
-        messages[msg] += 1
-    
-    deduped_errors = []
-    for msg, count in messages.items():
-        if count > 1:
-            deduped_errors.append(f'{count} occurrences of: {msg}')
-        else:
-            deduped_errors.append(msg)
+    # Deduplicate error and warning messages
+    errors = _dedupe_messages(validation_result.get_errors())
+    warnings = _dedupe_messages(validation_result.get_warnings())
 
-    error_messages = [{
-        'errorLevel': error_level,
-        'message': msg
-    } for msg in deduped_errors]
+    # Build error_messages list of dicts
+    error_messages = []
+    for msg in errors:
+        error_messages.append({'message': msg, 'errorLevel': 'error'})
+    for msg in warnings:
+        error_messages.append({'message': msg, 'errorLevel': 'warning'})
+    # Format HTML
     response_html_header = 'Validation ' + (
         'Successful' if bool(validation_result) else 'Unsuccessful')
     html_summary = f'<h3>{response_html_header}</h3>'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.32
+current_version = 0.1.33
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/mcneilco/acasclient',
-    version='0.1.32',
+    version='0.1.33',
     zip_safe=False,
 )

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -14,7 +14,7 @@ from acasclient import acasclient
 from acasclient.ddict import ACASDDict, ACASLsThingDDict
 from acasclient.lsthing import (BlobValue, CodeValue, FileValue, LsThingValue,
                                 SimpleLsThing, get_lsKind_to_lsvalue)
-from acasclient.validation import get_validation_response
+from acasclient.validation import ValidationResult, get_validation_response
 
 # SETUP
 # "bob" user name registered
@@ -853,3 +853,73 @@ class TestBlobValue(unittest.TestCase):
         assert blob_value_dict['value'] == value
         assert blob_value_dict['comments'] == comments
         assert blob_value_dict['id'] == id
+
+class TestValidationResponse(unittest.TestCase):
+
+    def setUp(self) -> None:
+        creds = acasclient.get_default_credentials()
+        self.client = acasclient.client(creds)
+
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+        self.client.close()
+
+    def test_001_response_with_errors_and_warnings(self):
+        """
+        Test creating a ValidationResponse with errors and warnings.
+        """
+        ERR_MSG = 'error 1'
+        WARN_MSG = 'warning 1'
+        # Create a warning
+        warn = ValidationResult(True, [WARN_MSG])
+        assert warn
+        assert len(warn.get_messages()) == 1
+        assert len(warn.get_warnings()) == 1
+        assert warn.get_warnings()[0] == WARN_MSG
+        assert len(warn.get_errors()) == 0
+
+        # Create an error
+        err = ValidationResult(False, [ERR_MSG])
+        assert not err
+        assert len(err.get_messages()) == 1
+        assert len(err.get_warnings()) == 0
+        assert len(err.get_errors()) == 1
+        assert err.get_errors()[0] == ERR_MSG
+
+        # Add them
+        valid = warn + err
+        assert not valid
+        assert len(valid.get_messages()) == 2
+        assert valid.get_messages()[0] == ERR_MSG
+        assert valid.get_messages()[1] == WARN_MSG
+        assert len(valid.get_errors()) == 1
+        assert valid.get_errors()[0] == ERR_MSG
+        assert len(valid.get_warnings()) == 1
+        assert valid.get_warnings()[0] == WARN_MSG
+
+        # Generate and check a response
+        response = get_validation_response(valid)
+        # Confirm the structure of the response body
+        assert response.get("commit") is False
+        self.assertEqual(response.get("transaction_id"), -1)
+        assert response.get("hasError") is True
+        assert response.get("hasWarning") is True
+        assert response.get("results") is not None
+        # Check we have two messages: one error, one warning
+        self.assertEqual(len(response.get("errorMessages")), 2)
+        self.assertEqual(response.get("errorMessages")[0].get("errorLevel"), "error")
+        self.assertEqual(response.get("errorMessages")[1].get("errorLevel"), "warning")
+        # Confirm HTML summary contains both messages
+        assert ERR_MSG in response['results']['htmlSummary']
+        assert WARN_MSG in response['results']['htmlSummary']
+
+        # Create a ValidationResult with error and warning at once
+        valid = ValidationResult(False, errors=[ERR_MSG], warnings=[WARN_MSG])
+        assert len(valid.get_messages()) == 2
+
+        # Create an invalid ValidationResult by giving an error message but saying it is valid
+        try:
+            invalid = ValidationResult(True, errors=[ERR_MSG], warnings=[WARN_MSG])
+            assert False
+        except ValueError as e:
+            assert str(e) == "ValidationResult cannot be valid and contain error messages"


### PR DESCRIPTION
- #43 added the ValidationResult class that handles a boolean "is_valid" status and a list of messages.
- This PR expands that to track warnings and errors separately, with backward compatibility to the simple "messages" interface. "messages" will be interpreted as either errors or warnings depending on the "is_valid" value.
- Also pulled @iamanandkr 's `get_validation_response` utility into the open source, then modified it to handle errors + warnings, not just messages.

Testing done:
- Ran acasclient unit tests

Other Information:
- This is still missing the ability to store a "Summary" block like the one SEL returns and convey it to the htmlSummary, but I'd prefer to tackle that separately.