### PR TITLE
Secure and expose Author and Role management APIs in acasclient

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -247,7 +247,7 @@ class client():
                             data=json.dumps(data),
                             allow_redirects=False)
         resp.raise_for_status()
-        if resp.status_code == 302 or ('location' in resp.headers and resp.headers.location == "/login"):
+        if resp.status_code == 302 and 'location' in resp.headers and resp.headers.get('location') == "/login":
             raise RuntimeError("Failed to login. Please check credentials.")
         return session
 

--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -244,9 +244,10 @@ class client():
         session = requests.Session()
         resp = session.post("{}/login".format(self.url),
                             headers={'Content-Type': 'application/json'},
-                            data=json.dumps(data))
+                            data=json.dumps(data),
+                            allow_redirects=False)
         resp.raise_for_status()
-        if 'location' in resp.headers and resp.headers.location == "/login":
+        if resp.status_code == 302 or ('location' in resp.headers and resp.headers.location == "/login"):
             raise RuntimeError("Failed to login. Please check credentials.")
         return session
 

--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -1463,6 +1463,19 @@ class client():
             'newAuthorRoles': new_author_roles or [],
             'authorRolesToDelete': author_roles_to_delete or [],
         }
+        resp = self.session.post("{}/api/updateAuthorRoles".format(self.url),
+                                    json=body)
+        resp.raise_for_status()
+        return resp.json()
+    
+    def update_project_roles(self, new_author_roles=None, author_roles_to_delete=None):
+        """
+        Same as update author roles but with a different endpoint name.
+        """
+        body = {
+            'newAuthorRoles': new_author_roles or [],
+            'authorRolesToDelete': author_roles_to_delete or [],
+        }
         resp = self.session.post("{}/api/projects/updateProjectRoles".format(self.url),
                                     json=body)
         resp.raise_for_status()

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -282,7 +282,7 @@ class BaseAcasClientTest(unittest.TestCase):
                 delete_backdoor_user(username)
         self.client.close()
 
-class TestAcasclient(unittest.TestCase):
+class TestAcasclient(BaseAcasClientTest):
     """Tests for `acasclient` package."""
 
     def setUp(self):

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -25,6 +25,8 @@ EMPTY_MOL = """
 M  END
 """
 
+ACAS_NODEAPI_BASE_URL = "http://localhost:3001"
+
 class Timeout:
     def __init__(self, seconds=1, error_message='Timeout'):
         self.seconds = seconds
@@ -225,57 +227,26 @@ def create_thing_with_blob_value(code):
     return ls_thing, file_name, bytes_array
 
 
-def acas_password_hash(password):
-    """ Returns a hash of the password in the form used by ACAS built-in authentication """
-    m = hashlib.sha1()
-    m.update(password.encode('UTF-8'))
-    enc = base64.b64encode(m.digest())
-    return enc.decode('UTF-8')
+def delete_backdoor_user(username):
+    """ Deletes a backdoor user created for testing purposes """
+    r = requests.delete(ACAS_NODEAPI_BASE_URL + "/api/systemTest/deleteTestUser/" + username)
+    r.raise_for_status()
 
 
-def create_backdoor_user(username, password, is_admin=False):
+def create_backdoor_user(username, password, acas_user=True, acas_admin=False, creg_user=False, creg_admin=False, project_names=None):
     """ Creates a backdoor user for testing purposes """
-    user = {
-        "firstName": username,
-        "lastName": username,
-        "emailAddress": username + "@example.com",
-        "userName": username,
-        "password": acas_password_hash(password),
-        "enabled": True,
-        "locked": False,
-        "recordedBy": "bob",
-        "lsType": "default",
-        "lsKind": "default",
+    body = {
+        "username": username,
+        "password": password,
+        "acasUser": acas_user,
+        "acasAdmin": acas_admin,
+        "cmpdregUser": creg_user,
+        "cmpdregAdmin": creg_admin,
+        "projectNames": project_names or []
     }
-    # POST the user to ACAS Roo directly. This only works if you are local to the ACAS server.
-    acas_roo_url = "http://localhost:8080/acas/api/v1/"
-    headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-    }
-    author_api_endpoint = acas_roo_url + "authors/jsonArray"
-    r = requests.post(author_api_endpoint, json=[user], headers=headers)
+    r = requests.post(ACAS_NODEAPI_BASE_URL + "/api/systemTest/getOrCreateTestUser", json=body)
     r.raise_for_status()
-    # Grant User or User + Admin roles to this user
-    user_role = {
-        "roleType": 'System',
-        "roleKind": 'ACAS',
-        "roleName": 'ROLE_ACAS-USERS',
-        "userName": username,
-    }
-    admin_role = {
-        "roleType": 'System',
-        "roleKind": 'ACAS',
-        "roleName": 'ROLE_ACAS-ADMINS',
-        "userName": username,
-    }
-    roles = [user_role]
-    if is_admin:
-        roles.append(admin_role)
-    # Sync roles
-    roles_api_endpoint = acas_roo_url + "authorroles/saveRoles"
-    r = requests.post(roles_api_endpoint, json=roles, headers=headers)
-    r.raise_for_status()
+    return r.json()
 
 class TestAcasclient(unittest.TestCase):
     """Tests for `acasclient` package."""
@@ -283,12 +254,14 @@ class TestAcasclient(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures, if any."""
         creds = acasclient.get_default_credentials()
+        self.test_usernames = []
         try:
             self.client = acasclient.client(creds)
         except RuntimeError:
-            # Create the test user if it doesn't exist
+            # Create the default user if it doesn't exist
             if creds.get('username'):
-                create_backdoor_user(creds.get('username'), creds.get('password'), is_admin=True)
+                create_backdoor_user(creds.get('username'), creds.get('password'), acas_user=True, acas_admin=True, creg_user=True, creg_admin=True)
+                self.test_usernames.append(creds.get('username'))
             # Login again
             self.client = acasclient.client(creds)
         self.tempdir = tempfile.mkdtemp()
@@ -298,6 +271,9 @@ class TestAcasclient(unittest.TestCase):
     def tearDown(self):
         """Tear down test fixtures, if any."""
         shutil.rmtree(self.tempdir)
+        if self.test_usernames:
+            for username in self.test_usernames:
+                delete_backdoor_user(username)
         self.client.close()
 
     def test_000_creds_from_file(self):

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -15,10 +15,8 @@ from acasclient.ddict import ACASDDict, ACASLsThingDDict
 from acasclient.lsthing import (BlobValue, CodeValue, FileValue, LsThingValue,
                                 SimpleLsThing, get_lsKind_to_lsvalue)
 from acasclient.validation import ValidationResult, get_validation_response
+from tests.test_acasclient import BaseAcasClientTest
 
-# SETUP
-# "bob" user name registered
-# "PROJ-00000001" registered
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -77,23 +75,21 @@ class Project(SimpleLsThing):
                                       preferred_label_kind=self.preferred_label_kind, metadata=metadata, ls_thing=ls_thing)
 
 
-class TestLsThing(unittest.TestCase):
+class TestLsThing(BaseAcasClientTest):
     """Tests for `acasclient lsthing` package model."""
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        creds = acasclient.get_default_credentials()
-        self.client = acasclient.client(creds)
-        self.tempdir = tempfile.mkdtemp()
+        super().setUp()
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
-        self.client.close()
         files_to_delete = ['dummy.pdf', 'dummy2.pdf']
         for f in files_to_delete:
             file = Path(f)
             if file.exists():
                 os.remove(file)
+        super().tearDown()
 
     # Helpers
     def _get_path(self, file_name):


### PR DESCRIPTION
## Description
- Certain scripts or admins need the ability to manage ACAS authors and their roles. However this access is highly sensitive and only admins should be able to create new users or alter their roles via the REST API.
- Added these methods to acasclient so they can be unit tested
- In order to properly test these routes and the admin-vs-non-admin permissions, I ended up adding a bunch of bootstrapping of new users in addition to "bob". The result is that the acasclient test suite can now run on a blank ACAS server that has not had "bob" or the Global project created beforehand.

## Related Issue

## How Has This Been Tested?
Confirmed acasclient tests passed on local dev instance.