### PR TITLE
ACAS-255: Add test for human-readable CReg SDF load report.log

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -687,6 +687,11 @@ class TestAcasclient(BaseAcasClientTest):
         self.assertIn('report_files', response)
         self.assertIn('summary', response)
         self.assertIn('Number of entries processed', response['summary'])
+        # Confirm the report.log file is created and is plaintext
+        report_log = [rf for rf in response['report_files'] if '_report.log' in rf['name']][0]
+        report_log_contents = report_log['content'].decode('utf-8')
+        self.assertIn('Number of entries processed', report_log_contents)
+        self.assertNotIn('<div', report_log_contents)
         return response
 
     def test_007_cmpd_search_request(self):


### PR DESCRIPTION
## Description
This is a test for https://github.com/mcneilco/acas-roo-server/pull/331

## Related Issue

## How Has This Been Tested?
Ran test locally before & after associated Roo change, confirmed test failed before, and passed after