### PR TITLE
Update basic csv to use µ character to test utf-8 encoding

### DIFF
--- a/tests/test_acasclient/uniform-commas-with-quoted-text.csv
+++ b/tests/test_acasclient/uniform-commas-with-quoted-text.csv
@@ -11,6 +11,6 @@ Project,Global,,
 ,,,
 Calculated Results,,,
 Datatype,Number,Number,Number
-Corporate Batch ID,t1/2 (min),In vitro Clint (uL/min/mg protein),Clint (mL/min/kg)
+Corporate Batch ID,t1/2 (min),In vitro Clint (µL/min/mg protein),Clint (mL/min/kg)
 "CMPD-0000001-001",4.36,159.04,"answer in a string,388.06"
 CMPD-0000001-001,3.31,2"09.43",511.02


### PR DESCRIPTION
## Description
Adds test for utf-8 encoding by updating the basic csv file

## Related Issue
ACAS-323

## How Has This Been Tested?
Ran acas client tests before and after utf-8 encoding testing.