### PR TITLE
Reimplement PyPI Publishing in GitHub Actions

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,30 @@
+name: Build and Publish to PyPI
+# Reference: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+on:
+  push:
+    branches: ["**"]
+  create:
+    tags: "**"
+jobs:
+  acasclient:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Install pypa/build and twine
+        run: |
+          python -m pip install build twine --user
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
+      - name: Publish to TestPyPI
+        run: |
+          python -m twine upload -u ${{ secrets.TEST_PYPI_USERNAME }} -p ${{ secrets.TEST_PYPI_PASSWORD }} --repository-url https://test.pypi.org/legacy/ dist/*
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          python -m twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/* 


### PR DESCRIPTION
## Description
Added a GitHub actions config to build python package and upload to TestPyPI on every commit, and to PyPI on tags.
I'm using the "twine" python package, but we could also use the pypi-publish github action instead https://github.com/marketplace/actions/pypi-publish

## Related Issue

## How Has This Been Tested?
Tested TestPyPI publishing locally using "act" https://github.com/nektos/act which was successful: https://test.pypi.org/project/acasclient/

I've set up tokens for both PyPI and TestPyPI as Secrets in GitHub Actions, but haven't tested this actually within GitHub yet.