### PR TITLE
ACAS-325: add GitHub action for running acasclient tests on latest ACAS release

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -23,7 +23,7 @@ jobs:
           python -m build --sdist --wheel --outdir dist/ .
       - name: Publish to TestPyPI
         run: |
-          python -m twine upload -u ${{ secrets.TEST_PYPI_USERNAME }} -p ${{ secrets.TEST_PYPI_PASSWORD }} --repository-url https://test.pypi.org/legacy/ dist/*
+          python -m twine upload --skip-existing -u ${{ secrets.TEST_PYPI_USERNAME }} -p ${{ secrets.TEST_PYPI_PASSWORD }} --repository-url https://test.pypi.org/legacy/ dist/*
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
         run: |

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
         run: |
-          python -m twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/* 
+          python -m twine upload --skip-existing -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/* 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -52,6 +52,7 @@ jobs:
         if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure == 'true' }}
       - name: Wait for startup then create docker bob
         run: bash docker_bob_setup.sh
+        working-directory: acas
       - name: Create bob credentials for acasclient
         run: |
           mkdir ~/.acas

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ jobs:
           path: acas
       - name: Set ACAS_TAG to latest release
         run: |
-          export ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas/releases/latest | jq -r '.tag_name')
+          echo "ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas/releases/latest | jq -r '.tag_name')" >> $GITHUB_ENV
       - name: Run docker-compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
         id: dockerComposeUp
         working-directory: acas
@@ -29,7 +29,7 @@ jobs:
           docker-compose -f "docker-compose.yml" up -d || echo ::set-output name=docker_compose_pull_failure::true
       - name: Get docker images fallback tag name
         run: |
-          echo "DEFAULT_BRANCH_ACAS_TAG=$(export ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas | jq -r '.default_branch'))" >> $GITHUB_ENV
+          echo "DEFAULT_BRANCH_ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas | jq -r '.default_branch' | sed -e 's/\//-/g')" >> $GITHUB_ENV
         if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure == 'true' }}
       - name: Falling back to ${{ env.DEFAULT_BRANCH_ACAS_TAG }} docker image tag for roo and racas tags
         working-directory: acas

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,5 +50,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ./acasclient
+      - name: Create bob credentials for acasclient
+        run: |
+          mkdir ~/.acas
+          echo "[default]" >> ~/.acas/credentials
+          echo "username=bob" >> ~/.acas/credentials
+          echo "password=secret" >> ~/.acas/credentials
+          echo "url=http://localhost:3000" >> ~/.acas/credentials
       - name: Run tests
         run: python -m unittest discover -s ./acasclient -p "test_*.py" -v

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,54 @@
+name: Launch ACAS and run python tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  acas:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout acasclient
+        uses: actions/checkout@v3
+        with:
+          path: acasclient
+      - name: Checkout ACAS
+        uses: actions/checkout@v3
+        with:
+          respository: mcneilco/acas
+          path: acas
+      - name: Set ACAS_TAG to latest release
+        run: |
+          export ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas/releases/latest | jq -r '.tag_name')
+      - name: Run docker-compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
+        id: dockerComposeUp
+        working-directory: acas
+        run: |
+          echo ::set-output name=docker_compose_pull_failure::false
+          docker-compose -f "docker-compose.yml" up -d || echo ::set-output name=docker_compose_pull_failure::true
+      - name: Get docker images fallback tag name
+        run: |
+          echo "DEFAULT_BRANCH_ACAS_TAG=$(export ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas | jq -r '.default_branch'))" >> $GITHUB_ENV
+        if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure == 'true' }}
+      - name: Falling back to ${{ env.DEFAULT_BRANCH_ACAS_TAG }} docker image tag for roo and racas tags
+        working-directory: acas
+        run: |
+          docker pull  mcneilco/acas-roo-server-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG }}-indigo
+          docker tag mcneilco/acas-roo-server-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG}}-indigo mcneilco/acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo
+          docker pull  mcneilco/racas-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG}}
+          docker tag mcneilco/racas-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG }} mcneilco/racas-oss:${{ env.ACAS_TAG }}
+          docker-compose -f "docker-compose.yml" up -d
+        if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure == 'true' }}
+      - name: Set Up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install acasclient and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ./acasclient
+      - name: Run tests
+        run: python -m unittest discover -s ./acasclient -p "test_*.py" -v

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout ACAS
         uses: actions/checkout@v3
         with:
-          respository: mcneilco/acas
+          repository: mcneilco/acas
           path: acas
       - name: Set ACAS_TAG to latest release
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,11 +13,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: acasclient
-      - name: Checkout ACAS
-        uses: actions/checkout@v3
-        with:
-          repository: mcneilco/acas
-          path: acas
       - name: Set Up Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -31,25 +26,17 @@ jobs:
       - name: Set ACAS_TAG to latest release
         run: |
           echo "ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas/releases/latest | jq -r '.tag_name')" >> $GITHUB_ENV
+      - name: Checkout ACAS
+        uses: actions/checkout@v3
+        with:
+          repository: mcneilco/acas
+          path: acas
+          ref: ${{ env.ACAS_TAG }}
       - name: Run docker-compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
         id: dockerComposeUp
         working-directory: acas
         run: |
-          echo ::set-output name=docker_compose_pull_failure::false
-          docker-compose -f "docker-compose.yml" up -d || echo ::set-output name=docker_compose_pull_failure::true
-      - name: Get docker images fallback tag name
-        run: |
-          echo "DEFAULT_BRANCH_ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas | jq -r '.default_branch' | sed -e 's/\//-/g')" >> $GITHUB_ENV
-        if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure == 'true' }}
-      - name: Falling back to ${{ env.DEFAULT_BRANCH_ACAS_TAG }} docker image tag for roo and racas tags
-        working-directory: acas
-        run: |
-          docker pull  mcneilco/acas-roo-server-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG }}-indigo
-          docker tag mcneilco/acas-roo-server-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG}}-indigo mcneilco/acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo
-          docker pull  mcneilco/racas-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG}}
-          docker tag mcneilco/racas-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG }} mcneilco/racas-oss:${{ env.ACAS_TAG }}
           docker-compose -f "docker-compose.yml" up -d
-        if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure == 'true' }}
       - name: Wait for startup then create docker bob
         run: bash docker_bob_setup.sh
         working-directory: acas

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,6 +18,16 @@ jobs:
         with:
           repository: mcneilco/acas
           path: acas
+      - name: Set Up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install acasclient and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ./acasclient
       - name: Set ACAS_TAG to latest release
         run: |
           echo "ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas/releases/latest | jq -r '.tag_name')" >> $GITHUB_ENV
@@ -40,16 +50,8 @@ jobs:
           docker tag mcneilco/racas-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG }} mcneilco/racas-oss:${{ env.ACAS_TAG }}
           docker-compose -f "docker-compose.yml" up -d
         if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure == 'true' }}
-      - name: Set Up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-      - name: Install acasclient and dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ./acasclient
+      - name: Wait for startup then create docker bob
+        run: bash docker_bob_setup.sh
       - name: Create bob credentials for acasclient
         run: |
           mkdir ~/.acas


### PR DESCRIPTION
Primary: @brianbolt 
Secondary: @dalejerikson 

- Added a new workflow that launches the latest release of ACAS in docker, then runs acasclient tests.
- This will run on PRs (including re-running on subsequent commits to a PR) and on all commits to the "main" branch
- Also fixed ACAS-324 pypi push failures by adding `--skip-existing` flag

Testing performed:
See successful passed checks in GitHub actions on this PR.