### PR TITLE
ACAS-343: Run acasclient tests against appropriate version of ACAS (PR for release/1.13.7)

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,30 @@
+name: Build and Publish to PyPI
+# Reference: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+on:
+  push:
+    branches: ["**"]
+  create:
+    tags: "**"
+jobs:
+  acasclient:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Install pypa/build and twine
+        run: |
+          python -m pip install build twine --user
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
+      - name: Publish to TestPyPI
+        run: |
+          python -m twine upload --skip-existing -u ${{ secrets.TEST_PYPI_USERNAME }} -p ${{ secrets.TEST_PYPI_PASSWORD }} --repository-url https://test.pypi.org/legacy/ dist/*
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          python -m twine upload --skip-existing -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/* 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,7 +2,7 @@ name: Launch ACAS and run python tests
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/*"]
   pull_request:
     types: [opened, synchronize]
 jobs:
@@ -23,15 +23,26 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ./acasclient
-      - name: Set ACAS_TAG to latest release
+      # The following steps are all to figure out the right ACAS_REF (git ref) and ACAS_TAG (docker tag) of ACAS to use
+      # If main or release branch, run tests on matching release branch of ACAS
+      - name: Set ACAS_REF to the current branch ${{ github.ref }}
         run: |
-          echo "ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas/releases/latest | jq -r '.tag_name')" >> $GITHUB_ENV
+          echo "ACAS_REF=${{ github.ref }}" >> $GITHUB_ENV
+        if: github.event_name == 'push'
+      # If a PR, run tests on ACAS branch matching destination of PR
+      - name: Set ACAS_REF to the PR destination branch ${{ github.base_ref }}
+        run: |
+          echo "ACAS_REF=${{ github.base_ref }}" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+      - name: Set ACAS_TAG to the docker escaped version of ${{ env.ACAS_REF }}
+        run: |
+          echo "ACAS_TAG=$(echo ${{ env.ACAS_REF }} | sed 's/\//-/g')" >> $GITHUB_ENV
       - name: Checkout ACAS
         uses: actions/checkout@v3
         with:
           repository: mcneilco/acas
           path: acas
-          ref: ${{ env.ACAS_TAG }}
+          ref: ${{ env.ACAS_REF }}
       - name: Run docker-compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
         id: dockerComposeUp
         working-directory: acas

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,51 @@
+name: Launch ACAS and run python tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  acas:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout acasclient
+        uses: actions/checkout@v3
+        with:
+          path: acasclient
+      - name: Set Up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install acasclient and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ./acasclient
+      - name: Set ACAS_TAG to latest release
+        run: |
+          echo "ACAS_TAG=$(curl -s https://api.github.com/repos/mcneilco/acas/releases/latest | jq -r '.tag_name')" >> $GITHUB_ENV
+      - name: Checkout ACAS
+        uses: actions/checkout@v3
+        with:
+          repository: mcneilco/acas
+          path: acas
+          ref: ${{ env.ACAS_TAG }}
+      - name: Run docker-compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
+        id: dockerComposeUp
+        working-directory: acas
+        run: |
+          docker-compose -f "docker-compose.yml" up -d
+      - name: Wait for startup then create docker bob
+        run: bash docker_bob_setup.sh
+        working-directory: acas
+      - name: Create bob credentials for acasclient
+        run: |
+          mkdir ~/.acas
+          echo "[default]" >> ~/.acas/credentials
+          echo "username=bob" >> ~/.acas/credentials
+          echo "password=secret" >> ~/.acas/credentials
+          echo "url=http://localhost:3000" >> ~/.acas/credentials
+      - name: Run tests
+        run: python -m unittest discover -s ./acasclient -p "test_*.py" -v

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -804,7 +804,7 @@ class TestAcasclient(unittest.TestCase):
         self.assertIn('<Parent Corp Name>\\nCMPD-0000001', content)
         self.assertIn('<Lot Corp Name>\\nCMPD-0000001-001', content)
         self.assertIn('<Project>\\nPROJ-00000001', content)
-        self.assertIn('<Parent Stereo Category>\\nunknown', content)
+        self.assertIn('<Parent Stereo Category>\\nUnknown', content)
         self.assertIn('content-type', search_results_export)
         self.assertIn('name', search_results_export)
         self.assertIn('content-length', search_results_export)
@@ -962,7 +962,7 @@ class TestAcasclient(unittest.TestCase):
 
     def test_017_get_experiment_by_code(self):
         """Test get experiment by code."""
-        experiment = self.client.get_experiment_by_code("EXPT-00000001")
+        experiment = self.client.get_experiment_by_code("EXPT-00000002")
         self.assertIn('codeName', experiment)
         self.assertIn('lsLabels', experiment)
         experiment = self.client.get_experiment_by_code("FAKECODE")
@@ -971,7 +971,7 @@ class TestAcasclient(unittest.TestCase):
     def test_018_get_source_file_for_experient_code(self):
         """Test get source file for experiment code."""
         source_file = self.client.\
-            get_source_file_for_experient_code("EXPT-00000001")
+            get_source_file_for_experient_code("EXPT-00000002")
         self.assertIn('content', source_file)
         self.assertIn('content-type', source_file)
         self.assertIn('name', source_file)
@@ -984,7 +984,7 @@ class TestAcasclient(unittest.TestCase):
     def test_019_write_source_file_for_experient_code(self):
         """Test get source file for experiment code."""
         source_file_path = self.client.\
-            write_source_file_for_experient_code("EXPT-00000001", self.tempdir)
+            write_source_file_for_experient_code("EXPT-00000002", self.tempdir)
         self.assertTrue(source_file_path.exists())
 
     def test_020_get_meta_lot(self):


### PR DESCRIPTION
## Description
Modify acasclient GitHub Actions to run against correlated ACAS branch. This is the 2nd of 4 PRs, following #74 . This PR applies the same change to `release/1.13.7`.

Changes:
- For commits to main and release/* branches (i.e. release/1.13.7, release/2022.1.x), run tests against the corresponding ACAS branch by the same name.
- For pull requests, run acasclient tests against the target branch, i.e. ACAS release/2022.1.x if the acasclient PR is targeting release/2022.1.x
- Fixed a few flaky / failing tests specific to `release/1.13.7` branch


## Related Issue

## How Has This Been Tested?
See successful tests job in the "check" on this PR: https://github.com/mcneilco/acasclient/runs/7511431603?check_suite_focus=true