### PR TITLE
ACAS-367: partial revert

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2317,7 +2317,7 @@ class TestAcasclient(BaseAcasClientTest):
             # to complete. On my machine it takes 30 seconds.
             # This is a performance check to make sure the
             # bulk load hasn't slowed significantly.
-            with Timeout(seconds=60):
+            with Timeout(seconds=90):
                 response = self.basic_cmpd_reg_load(file = file)
         except TimeoutError:
             self.fail("Timeout error")

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3290,24 +3290,28 @@ class TestExperimentLoader(BaseAcasClientTest):
     
     @requires_basic_cmpd_reg_load
     def test_012_escaped_quotes_csv(self):
-        """Test experiment loader with escaped quotes in csv file"""
+        """Test experiment loader with escaped quotes in csv file
+        This is a negative test - the experiment load is expected to fail at present. """
         data_file_to_upload = Path(__file__).resolve()\
             .parent.joinpath('test_acasclient', 'escaped_quotes.csv')
+        # Validate the experiment
         self.experiment_load_test(data_file_to_upload, True)
-        response = self.experiment_load_test(data_file_to_upload, False)
-        # Check the loaded experiment
-        experiment = self.client.\
-            get_experiment_by_code(response['results']['experimentCode'], full = True)
-        self.assertIsNotNone(experiment)
-        self.assertIn("analysisGroups", experiment)
-        # Find the clobValue
-        clob_value = None
-        for analysis_group in experiment["analysisGroups"]:
-            for state in analysis_group["lsStates"]:
-                for value in state["lsValues"]:
-                    if value["lsKind"] == "Test JSON":
-                        clob_value = value["clobValue"]
-        # Ensure the clob value can be parsed as JSON
-        self.assertIsNotNone(clob_value)
-        parsed_json = json.loads(clob_value)
-        self.assertIsNotNone(parsed_json)
+        # Try to load and commit - this is expected to fail
+        with self.assertRaises(AssertionError) as context:
+            response = self.experiment_load_test(data_file_to_upload, False)
+        # # Check the loaded experiment
+        # experiment = self.client.\
+        #     get_experiment_by_code(response['results']['experimentCode'], full = True)
+        # self.assertIsNotNone(experiment)
+        # self.assertIn("analysisGroups", experiment)
+        # # Find the clobValue
+        # clob_value = None
+        # for analysis_group in experiment["analysisGroups"]:
+        #     for state in analysis_group["lsStates"]:
+        #         for value in state["lsValues"]:
+        #             if value["lsKind"] == "Test JSON":
+        #                 clob_value = value["clobValue"]
+        # # Ensure the clob value can be parsed as JSON
+        # self.assertIsNotNone(clob_value)
+        # parsed_json = json.loads(clob_value)
+        # self.assertIsNotNone(parsed_json)


### PR DESCRIPTION
## Description
Original fix for ACAS-367 tried to fix two issues - one with misaligned quote escaping between R and Roo, and another with R being unable to read files with `""` escaped double quotes, rather than `\"` escaped.
The fix for the second issue introduced new bugs, so it has now been reverted: https://github.com/mcneilco/racas/commit/952d5a97d5dcae94b8215c21688dc5ddbda63c46

This PR updates the python test for that second issue, and switches it to expect failure. I thought that keeping the test and recording the fact that it fails was more valuable than simply removing the test, but I'm open to other opinions there.

## Related Issue

## How Has This Been Tested?
Tested acasclient locally. Will confirm with automated test on this PR.