### PR TITLE
Add 401 status code check and test for failed login to client initialization

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -768,6 +768,14 @@ class TestAcasclient(BaseAcasClientTest):
         client = acasclient.client(creds)
         client.close()
 
+        # Verify bad creds 401 response
+        bad_creds = acasclient.get_default_credentials()
+        bad_creds['password'] = 'badpassword'
+        with self.assertRaises(RuntimeError) as context:
+            acasclient.client(bad_creds)
+        self.assertIn('Failed to login. Please check credentials.', str(context.exception))
+
+
     def test_003_projects(self):
         """Test projects."""
         projects = self.client.projects()


### PR DESCRIPTION
## Description

- For ACAS 2021.1.x detect no login by checking 401 status code.
- Keeps backwards compatibility for 302 and /login redirect for older versions of ACAS.


## Related Issue
ACAS-389

## How Has This Been Tested?
Verified that new and old ACAS work with this detection method.
