### PR TITLE
Expanded tests for delete_lot, including coverage for disableDeleteMyLots config

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -400,10 +400,10 @@ class BaseAcasClientTest(unittest.TestCase):
             self.client.close()
 
     @requires_node_api
-    def create_and_connect_backdoor_user(self, username = None, password = None, **kwargs):
+    def create_and_connect_backdoor_user(self, username = None, password = None, prefix = "acas-user-", **kwargs):
         """ Creates a backdoor user and connects them to the ACAS node API """
         if username is None:
-            username = "acas-user-"+str(uuid.uuid4())
+            username = prefix+str(uuid.uuid4())
         if password is None:
             password = str(uuid.uuid4())
         create_backdoor_user(username = username, password = password, **kwargs)
@@ -2701,12 +2701,12 @@ class TestCmpdReg(BaseAcasClientTest):
         project = self.create_basic_project_with_roles()
 
         # Create a bunch of users with various roles and project access
-        cmpdreg_user = self.create_and_connect_backdoor_user(acas_user=False, acas_admin=False, creg_user=True, creg_admin=False)
-        cmpdreg_user_with_restricted_project_acls = self.create_and_connect_backdoor_user(acas_user=False, acas_admin=False, creg_user=True, creg_admin=False, project_names = [project.names[PROJECT_NAME]])
-        acas_user = self.create_and_connect_backdoor_user(acas_user=True, acas_admin=False, creg_user=False, creg_admin=False)
-        acas_user_restricted_project_acls = self.create_and_connect_backdoor_user(acas_user=True, acas_admin=False, creg_user=False, creg_admin=False, project_names = [project.names[PROJECT_NAME]])
-        acas_admin = self.create_and_connect_backdoor_user(acas_user=True, acas_admin=True, creg_user=False, creg_admin=False)
-        cmpdreg_admin = self.create_and_connect_backdoor_user(acas_user=False, acas_admin=False, creg_user=True, creg_admin=True)
+        cmpdreg_user = self.create_and_connect_backdoor_user(prefix="cmpdreg-user-", acas_user=False, acas_admin=False, creg_user=True, creg_admin=False)
+        cmpdreg_user_with_restricted_project_acls = self.create_and_connect_backdoor_user(prefix="cmpdreg-user-acls-", acas_user=False, acas_admin=False, creg_user=True, creg_admin=False, project_names = [project.names[PROJECT_NAME]])
+        acas_user = self.create_and_connect_backdoor_user(prefix="acas-user-", acas_user=True, acas_admin=False, creg_user=False, creg_admin=False)
+        acas_user_restricted_project_acls = self.create_and_connect_backdoor_user(prefix="acas-user-acls-", acas_user=True, acas_admin=False, creg_user=False, creg_admin=False, project_names = [project.names[PROJECT_NAME]])
+        acas_admin = self.create_and_connect_backdoor_user(prefix="acas-admin-", acas_user=True, acas_admin=True, creg_user=False, creg_admin=False)
+        cmpdreg_admin = self.create_and_connect_backdoor_user(prefix="cmpdreg-admin-", acas_user=False, acas_admin=False, creg_user=True, creg_admin=True)
 
         def can_delete_lot(self, user_client, lot_corp_name, set_owner_first=True):
             if set_owner_first:

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2769,7 +2769,7 @@ class TestCmpdReg(BaseAcasClientTest):
         # Deny rule: ACAS admin is not a creg admin
         self.assertFalse(can_delete_lot(self, acas_admin, restricted_lot_corp_name, set_owner_first=True))
 
-        # Deny rule: CregAdmin/ACASAdmin can delete the lot and assay data
+        # Allow rule: CregAdmin/ACASAdmin can delete the lot and assay data
         self.assertTrue(can_delete_lot(self, self.client, restricted_lot_corp_name, set_owner_first=True))
 
         # Verify lot is actually deleted

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2779,7 +2779,7 @@ class TestCmpdReg(BaseAcasClientTest):
         # Get the experiment and verify the lot is deleted
         self.assertFalse(check_lot_exists_in_experiment(self, restricted_lot_corp_name, response['results']['experimentCode']))
 
-        # TODO: The following tests depent on a non default configuration: client.cmpdreg.metaLot.disableDeleteMyLots = false so we can't test this by default. We should turn this back on when we have a testing system which can change the configurations of acas.
+        # TODO: The following tests are dependent on a non default configuration: client.cmpdreg.metaLot.disableDeleteMyLots = false so we can't test this by default. We should turn this back on when we have a testing system which can change the configurations of acas.
         # # Global compound, with experiment in Global project
         # ## Deny Rule: Not an acas user so can't delete because dependent experiment exists
         # self.assertFalse(can_delete_lot(self, cmpdreg_user, "CMPD-0000001-001", set_owner_first=True))

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2725,7 +2725,7 @@ class TestCmpdReg(BaseAcasClientTest):
             experiment = self.client.get_experiment_by_code(experiment_code_name, full = True)
             # when experiment is deleted, the analysis groups for the lot are deleted
             for analysis_group in experiment["analysisGroups"]:
-                if analysis_group["deleted"] == True:
+                if analysis_group["deleted"] == True or analysis_group["ignored"] == True:
                     continue
                 for state in analysis_group["lsStates"]:
                     for value in state["lsValues"]:


### PR DESCRIPTION
## Description
 Modify delete_lot tests to account for new default config `client.cmpdreg.metaLot.disableDeleteMyLots` which disables all deleting of lots if user is not a creg admin

## Related Issue
ACAS-408

## How Has This Been Tested?
Ran default acas client tests with default acas setting `client.cmpdreg.metaLot.disableDeleteMyLots` = `true`
Ran `TODO` tests which are the non-default tests for when `client.cmpdreg.metaLot.disableDeleteMyLots` = `false`