### PR TITLE
ACAS-404: Update swap_parent_structures API to return error information.

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -11,6 +11,8 @@ import re
 import base64
 import hashlib
 from io import StringIO, IOBase
+from typing import Dict
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -1843,7 +1845,7 @@ class client():
         resp.raise_for_status()
         return resp.json()
 
-    def swap_parent_structures(self, corp_name1: str, corp_name2: str) -> bool:
+    def swap_parent_structures(self, corp_name1: str, corp_name2: str) -> Dict[str, str]:
         """Swap parent structures.
 
         Args:
@@ -1851,13 +1853,18 @@ class client():
             corp_name2 (str): Corporate ID of the second parent compound.
 
         Returns:
-            Whether structures were swapped.
+            A dict with "hasError" and "errorMessage" keys. For example
+            {
+                "hasError": True,
+                "errorMessage": "Swapping corpName1=CMPD-1 & corpName2=CMPD-2 creates duplicates."
+            }
         """
 
         data = {'corpName1': corp_name1, 'corpName2': corp_name2}
         resp = self.session.post(f'{self.url}/cmpdreg/swapParentStructures/', json=data)
-        resp.raise_for_status()
-        return not resp.json()["hasError"]
+        if resp.status_code != 500:
+            resp.raise_for_status()
+        return resp.json()
         
     def reparent_lot(self, lot_corp_name, new_parent_corp_name, dry_run=True):
         """Reparent a lot

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -667,13 +667,13 @@ class BaseAcasClientTest(unittest.TestCase):
                     "dbProperty": "Parent Stereo Category",
                     "defaultVal": STEREO_CATEGORY,
                     "required": True,
-                    "sdfProperty": None
+                    "sdfProperty": "Parent Stereo Category"
                 },
                 {
                     "dbProperty": "Parent Stereo Comment",
                     "defaultVal": None,
                     "required": False,
-                    "sdfProperty": "Structure Comment"
+                    "sdfProperty": "Parent Stereo Comment"
                 },
                 {
                     "dbProperty": "Lot Is Virtual",
@@ -2853,27 +2853,37 @@ class TestCmpdReg(BaseAcasClientTest):
 
         try:
             # Swapping 1 and 3 will introduce duplicacy between 1 and 2.
-            with self.assertRaises(requests.exceptions.HTTPError):
-                self.client.swap_parent_structures(
-                    corp_name1='CMPD-0000001', corp_name2='CMPD-0000003')
+            exp_error_msg = ("Swapping corpName1=CMPD-0000001 & "
+                    "corpName2=CMPD-0000003 creates duplicates.")
+            response = self.client.swap_parent_structures(
+                corp_name1='CMPD-0000001', corp_name2='CMPD-0000003')
+            assert response["hasError"] is True
+            self.assertEqual(response["errorMessage"], exp_error_msg)
 
             # Swapping 1 and 2 will not introduce any duplicates.
-            assert self.client.swap_parent_structures(
+            response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000001', corp_name2='CMPD-0000002')
+            self.assertFalse(response["hasError"])
+
             # Restore the original structures
-            assert self.client.swap_parent_structures(
+            response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000001', corp_name2='CMPD-0000002')
+            self.assertFalse(response["hasError"])  # Sanity Check
 
             # Swapping 1 and 4 will not introduce any duplicates.
-            assert self.client.swap_parent_structures(
+            response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000001', corp_name2='CMPD-0000004')
+            self.assertFalse(response["hasError"])
+
             # Restore the original structures
-            assert self.client.swap_parent_structures(
+            response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000001', corp_name2='CMPD-0000004')
+            self.assertFalse(response["hasError"])  # Sanity Check
 
             # Swapping 5 and 6 will not introduce any duplicates.
-            assert self.client.swap_parent_structures(
+            response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000005', corp_name2='CMPD-0000006')
+            self.assertFalse(response["hasError"])
         finally:
             # Prevent interaction with other tests.
             self.delete_all_cmpd_reg_bulk_load_files()

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2883,7 +2883,7 @@ class TestCmpdReg(BaseAcasClientTest):
             _check_mol_weights('CMPD-0000002-001', exp_002_tuple[0], exp_002_tuple[1], exp_002_tuple[2])
 
             # Swapping 1 and 2 will not introduce any duplicates.
-            assert self.client.swap_parent_structures(
+            response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000001', corp_name2='CMPD-0000002')
             self.assertFalse(response["hasError"])
 
@@ -2891,7 +2891,7 @@ class TestCmpdReg(BaseAcasClientTest):
             _check_mol_weights('CMPD-0000001-001', exp_002_tuple[0], exp_002_tuple[1], exp_002_tuple[2])
             _check_mol_weights('CMPD-0000002-001', exp_001_tuple[0], exp_001_tuple[1], exp_001_tuple[2])
             # Restore the original structures
-            assert self.client.swap_parent_structures(
+            response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000001', corp_name2='CMPD-0000002')
             self.assertFalse(response["hasError"])  # Sanity Check
             # Check the molweights and mol formulas have been restored
@@ -2899,7 +2899,7 @@ class TestCmpdReg(BaseAcasClientTest):
             _check_mol_weights('CMPD-0000002-001', exp_002_tuple[0], exp_002_tuple[1], exp_002_tuple[2])
 
             # Swapping 1 and 4 will not introduce any duplicates.
-            assert self.client.swap_parent_structures(
+            response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000001', corp_name2='CMPD-0000004')
             self.assertFalse(response["hasError"])
 

--- a/tests/test_acasclient/test_005_swap_parent_structures.sdf
+++ b/tests/test_acasclient/test_005_swap_parent_structures.sdf
@@ -179,7 +179,7 @@ CMPD-0000003
 3
 
 >  <Parent Stereo Category>
-Unknown
+Single stereoisomer - arbitrary assign
 
 >  <Parent Stereo Comment>
 
@@ -291,10 +291,10 @@ CMPD-0000006
 6
 
 >  <Parent Stereo Category>
-Single stereoisomer - partial assign
+Unknown
 
 >  <Parent Stereo Comment>
-
+bar
 
 >  <Parent Mol Weight>
 158.256
@@ -403,10 +403,10 @@ CMPD-0000005
 5
 
 >  <Parent Stereo Category>
-Single stereoisomer - arbitrary assign
+Unknown
 
 >  <Parent Stereo Comment>
-
+foo
 
 >  <Parent Mol Weight>
 158.256


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update `swap_parent_structures` API to instead return a dictionary with `hasError` and `errorMessage` keys.

## Description
<!--- Describe your changes in detail -->
`swap_parent_structures` API doesn't produce any meaningful error message in case of failure. Here we update the API to pass the json with `hasError` & `errorMessage` returned from the roo layer to the caller.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-404](https://jira.schrodinger.com/browse/ACAS-404).

## How Has This Been Tested?
<!--- Describe how this has been tested -->
TDD.