### PR TITLE
Update tests to check swapParentStructures API behaviour with parent aliases.

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2926,7 +2926,7 @@ class TestCmpdReg(BaseAcasClientTest):
             _check_mol_weights('CMPD-0000006-001', exp_005_tuple[0], exp_005_tuple[1], exp_005_tuple[2])
 
             # Swap with a non-existant corporate name.
-            exp_error_msg = ("No parent or unique alias found for foo")
+            exp_error_msg = ("'foo' was not found as a corporate id or as an alias")
             response = self.client.swap_parent_structures(
                 corp_name1="CMPD-0000001", corp_name2="foo"
             )
@@ -2939,7 +2939,7 @@ class TestCmpdReg(BaseAcasClientTest):
             self.assertFalse(response["hasError"])
 
             # Swap a non-unique alias.
-            exp_error_msg = ("No parent or unique alias found for alias-4")
+            exp_error_msg = ("Alias name 'alias-4' has multiple corporate id matches: CMPD-0000004, CMPD-0000005")
             response = self.client.swap_parent_structures(
                 corp_name1='CMPD-0000006', corp_name2='alias-4'
             )

--- a/tests/test_acasclient/test_005_swap_parent_structures.sdf
+++ b/tests/test_acasclient/test_005_swap_parent_structures.sdf
@@ -97,6 +97,8 @@ C5 H11 Cl
 
 >  <Parent Comment>
 
+>  <Parent Aliases>
+alias-2
 
 $$$$
 
@@ -198,6 +200,8 @@ C5 H11 Cl
 
 >  <Parent Comment>
 
+>  <Parent Aliases>
+alias-3
 
 $$$$
 
@@ -310,6 +314,8 @@ C10 H19 F
 
 >  <Parent Comment>
 
+>  <Parent Aliases>
+alias-6; alias-6a;
 
 $$$$
 
@@ -422,6 +428,8 @@ C10 H19 F
 
 >  <Parent Comment>
 
+ >  <Parent Aliases>
+alias-4
 
 $$$$
 
@@ -520,6 +528,8 @@ C4 H8
 
 >  <Parent Comment>
 
+>  <Parent Aliases>
+alias-4
 
 $$$$
 
@@ -621,5 +631,7 @@ C5 H11 Cl
 
 >  <Parent Comment>
 
+>  <Parent Aliases>
+alias-1
 
 $$$$


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add tests to check `swapParentStructures` API can swap parent structures for unique parent aliases passed as corporate name.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-440](https://jira.schrodinger.com/browse/ACAS-440).
https://github.com/mcneilco/acas-roo-server/pull/366

## How Has This Been Tested?
<!--- Describe how this has been tested -->
Ran existing and new conditions.