### PR TITLE
Show `swapParentStructures` errors to the client.

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -1862,7 +1862,7 @@ class client():
 
         data = {'corpName1': corp_name1, 'corpName2': corp_name2}
         resp = self.session.post(f'{self.url}/cmpdreg/swapParentStructures/', json=data)
-        if resp.status_code != 500:
+        if resp.status_code != 400:
             resp.raise_for_status()
         return resp.json()
         


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`swapParentStructures` API in `acas-roo-server` is updated to return a `BAD_REQUEST` when the swap of parent structures fails due to invalid corporate name or other invalid criteria. Here we update the client code to ignore `400` status code in response as we want the error message to be propagated to the end user.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-430](https://jira.schrodinger.com/browse/ACAS-430)
https://github.com/mcneilco/acas-roo-server/pull/369
## How Has This Been Tested?
<!--- Describe how this has been tested -->
Ran all acasclient tests.