### PR TITLE
ACAS-507: Add edit parent to acasclient

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -2032,3 +2032,17 @@ class client():
         
         # Persist the update
         self.save_meta_lot(meta_lot)
+    
+    def edit_parent(self, parent, dry_run=True) -> Dict:
+        """Makes changes to an existing parent.
+        Returns a dictionary of affected lots
+        """
+        if dry_run:
+            url = "{}/cmpdreg/validateParent".format(self.url)
+        else:
+            url = "{}/cmpdreg/updateParent".format(self.url)
+        resp = self.session.post(url,
+                                 headers={'Content-Type': "application/json"},
+                                 data=json.dumps(parent))
+        resp.raise_for_status()
+        return resp.json()

--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -11,7 +11,7 @@ import re
 import base64
 import hashlib
 from io import StringIO, IOBase
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -2033,16 +2033,30 @@ class client():
         # Persist the update
         self.save_meta_lot(meta_lot)
     
-    def edit_parent(self, parent, dry_run=True) -> Dict:
+    def edit_parent(self, parent, dry_run=True) -> Tuple[bool, Dict]:
         """Makes changes to an existing parent.
-        Returns a dictionary of affected lots
+        Returns (status, data) where `status` is a bool representing success (True) or failure (False)
+        `data` is a dict of supporting information. In case of failure it contains a list of duplicates
+        In case of success it contains a list of affected lots
         """
-        if dry_run:
-            url = "{}/cmpdreg/validateParent".format(self.url)
-        else:
-            url = "{}/cmpdreg/updateParent".format(self.url)
-        resp = self.session.post(url,
+        # Validate
+        resp = self.session.post("{}/cmpdreg/validateParent".format(self.url),
                                  headers={'Content-Type': "application/json"},
                                  data=json.dumps(parent))
         resp.raise_for_status()
-        return resp.json()
+        resp_data = resp.json()
+        success = True
+        # Check whether the response just has a list of affected lots or whether
+        # It has a list of dupeParents
+        if 'parentUnique' in resp_data and not resp_data['parentUnique']:
+            success = False
+        # If just doing validation, or if validation failed, return response
+        if dry_run or not success:
+            return success, resp.json()
+        # Otherwise continue to updateParent
+        resp = self.session.post("{}/cmpdreg/updateParent".format(self.url),
+                                 headers={'Content-Type': "application/json"},
+                                 data=json.dumps(parent))
+        resp.raise_for_status()
+        resp_data = resp.json()
+        return success, resp_data

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3430,43 +3430,70 @@ class TestCmpdReg(BaseAcasClientTest):
             TEST_STEREO_COMMENT = 'test stereo comment'
             TEST_STEREO_CAT_CODE = 'No stereochemistry'
             # Get parent 1
-            meta_lot_1 = self.client.get_meta_lot('CMPD-0000001-001')
-            parent_1 = meta_lot_1['lot']['parent']
+            meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
+            parent = meta_lot['lot']['parent']
+            ORIG_STEREO_COMMENT = parent['stereoComment']
+            ORIG_STEREO_CAT_CODE = parent['stereoCategory']['code']
+            # Get parent 2
+            meta_lot_2 = self.client.get_meta_lot('CMPD-0000002-001')
+            parent_2 = meta_lot_2['lot']['parent']
+            CMPD_2_STRUCTURE = parent_2['molStructure']
             # TODO make change to structure
             # Make changes to stereo category, stereo comment
-            parent_1['stereoComment'] = TEST_STEREO_COMMENT
-            parent_1['stereoCategory'] = stereo_cat_dict[TEST_STEREO_CAT_CODE]
+            parent['stereoComment'] = TEST_STEREO_COMMENT
+            parent['stereoCategory'] = stereo_cat_dict[TEST_STEREO_CAT_CODE]
             # Validate
-            validation_resp = self.client.edit_parent(parent_1, dry_run=True)
-            print(validation_resp)
+            validation_status, validation_resp = self.client.edit_parent(parent, dry_run=True)
             # Confirm validation response mentions the lot
+            self.assertTrue(validation_status)
             self.assertEquals(len(validation_resp), 1)
             self.assertEquals(validation_resp[0]['code'], 'CMPD-0000001-001')
             self.assertEquals(validation_resp[0]['name'], 'CMPD-0000001-001')
             # Commit the edit
-            self.client.edit_parent(parent_1, dry_run=False)
+            edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
+            # Confirm edit response mentions the lot
+            self.assertTrue(edit_status)
+            self.assertEquals(len(edit_resp), 1)
+            self.assertEquals(edit_resp[0]['code'], 'CMPD-0000001-001')
+            self.assertEquals(edit_resp[0]['name'], 'CMPD-0000001-001')
             # Get the parent again and check out changes were made
-            updated_meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
-            updated_parent = updated_meta_lot['lot']['parent']
-            self.assertEquals(updated_parent['stereoComment'], TEST_STEREO_COMMENT)
-            self.assertEquals(updated_parent['stereoCategory']['code'], TEST_STEREO_CAT_CODE)
+            meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
+            parent = meta_lot['lot']['parent']
+            self.assertEquals(parent['stereoComment'], TEST_STEREO_COMMENT)
+            self.assertEquals(parent['stereoCategory']['code'], TEST_STEREO_CAT_CODE)
             # Confirm a non-admin cannot attempt a dry run edit
             with self.assertRaises(requests.HTTPError) as context:
-                response = cmpdreg_user.edit_parent(parent_1, dry_run=True)
+                cmpdreg_user.edit_parent(parent, dry_run=True)
             self.assertIn('401 Client Error: Unauthorized for url', str(context.exception))
             # Confirm a non-admin cannot edit
             with self.assertRaises(requests.HTTPError) as context:
-                response = cmpdreg_user.edit_parent(parent_1, dry_run=False)
+                cmpdreg_user.edit_parent(parent, dry_run=False)
             self.assertIn('401 Client Error: Unauthorized for url', str(context.exception))
-            
-            # TODO edit back to how it was before
-            # TODO save
-            # TODO edit structure to match parent 2
-            # TODO validate (should it fail?)
-            # TODO save (should fail)
-            # TODO test non-admin cannot make any edits
-            #TODO remove placeholder
-            self.assertFalse(True)
+            # Edit back to how it was before and save
+            parent['stereoComment'] = ORIG_STEREO_COMMENT
+            parent['stereoCategory'] = stereo_cat_dict[ORIG_STEREO_CAT_CODE]
+            self.client.edit_parent(parent, dry_run=False)
+            # Confirm attributes are back to as they were before
+            meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
+            parent = meta_lot['lot']['parent']
+            self.assertEquals(parent['stereoComment'], ORIG_STEREO_COMMENT)
+            self.assertEquals(parent['stereoCategory']['code'], ORIG_STEREO_CAT_CODE)
+            # Edit structure to match parent 2
+            # This should result in a duplicate, and thus be blocked
+            parent['molStructure'] = CMPD_2_STRUCTURE
+            # Validate (should fail)
+            validation_status, validation_resp = self.client.edit_parent(parent, dry_run=True)
+            self.assertFalse(validation_status)
+            self.assertFalse(validation_resp['parentUnique'])
+            self.assertEquals(len(validation_resp['dupeParents']), 1)
+            self.assertEquals(validation_resp['dupeParents'][0]['corpName'], 'CMPD-0000002')
+            # Attempt non-dryrun (should fail)
+            edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
+            self.assertFalse(edit_status)
+            self.assertFalse(edit_status)
+            self.assertFalse(edit_resp['parentUnique'])
+            self.assertEquals(len(edit_resp['dupeParents']), 1)
+            self.assertEquals(edit_resp['dupeParents'][0]['corpName'], 'CMPD-0000002')
         finally:
             # Prevent interaction with other tests.
             self.delete_all_cmpd_reg_bulk_load_files()

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3091,6 +3091,7 @@ class TestCmpdReg(BaseAcasClientTest):
         # self.assertTrue(can_delete_lot(self, cmpdreg_user_with_restricted_project_acls, restricted_lot_corp_name, set_owner_first=True))
 
     @requires_absent_basic_cmpd_reg_load
+    @requires_node_api
     def test_005_swap_parent_structures(self):
         """
         Check `swap_parent_structures` can swap structures in case of parents with no duplicates or
@@ -3199,6 +3200,14 @@ class TestCmpdReg(BaseAcasClientTest):
             )
             self.assertTrue(response["hasError"])
             self.assertEqual(response["errorMessage"], exp_error_msg)
+
+            # Try making a valid swap as a non-admin and confirm it fails
+            # due to permissions
+            cmpdreg_user = self.create_and_connect_backdoor_user(acas_user=False, acas_admin=False, creg_user=True, creg_admin=False)
+            with self.assertRaises(requests.HTTPError) as context:
+                response = cmpdreg_user.swap_parent_structures(
+                    corp_name1='CMPD-0000001', corp_name2='CMPD-0000002')
+            self.assertIn('401 Client Error: Unauthorized for url', str(context.exception))
         finally:
             # Prevent interaction with other tests.
             self.delete_all_cmpd_reg_bulk_load_files()


### PR DESCRIPTION
## Description
- Add `edit_parent` method which does both validation and actual edits. I discovered that the updateParent route doesn't perform validation, so I made this method always run validation before calling updateParent. Added a few tests confirming valid edits go through, and edits that would create duplicates are rejected.
- Tried to confirm that edit parent is an admin-only function and discovered it was not, so made an ACAS change (https://github.com/mcneilco/acas/pull/1047)
- Also updated swap_structures test to verify it now is admin-only
## Related Issue

## How Has This Been Tested?
Ran ACASClient tests locally using ACAS branch `ACAS-507`
(see https://github.com/mcneilco/acas/pull/1047)