### PR TITLE
ACAS-550: Hopeful fix for flakey edit_parent test

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3,6 +3,7 @@
 """Tests for `acasclient` package."""
 
 from functools import wraps
+from time import sleep
 import unittest
 from acasclient import acasclient
 from pathlib import Path
@@ -3486,6 +3487,8 @@ class TestCmpdReg(BaseAcasClientTest):
             parent['stereoComment'] = ORIG_STEREO_COMMENT
             parent['stereoCategory'] = stereo_cat_dict[ORIG_STEREO_CAT_CODE]
             self.client.edit_parent(parent, dry_run=False)
+            # Sleep for 50 ms to make sure change to the parent has been committed
+            sleep(0.05)
             # Confirm attributes are back to as they were before
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']


### PR DESCRIPTION
## Description
- Could not reproduce the issue locally, but I'm making a guess that the problem is that the "get_meta_lot" call is happening so soon after the edit_parent call that it hasn't had time to commit the change to the parent. Testing out a fix which is to add a 50ms wait after the edit parent call to give time for the commit to happen before re-fetching the metalot.

## Related Issue

## How Has This Been Tested?
Local tests still pass, but the real test will be on this PR.