### PR TITLE
ACAS-550: Fix flakey edit_parent test

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3,7 +3,6 @@
 """Tests for `acasclient` package."""
 
 from functools import wraps
-from time import sleep
 import unittest
 from acasclient import acasclient
 from pathlib import Path
@@ -3446,6 +3445,7 @@ class TestCmpdReg(BaseAcasClientTest):
             # Get parent 1
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']
+            print(f"DEBUG: parent version: {parent['version']}")
             ORIG_STEREO_COMMENT = parent['stereoComment']
             ORIG_STEREO_CAT_CODE = parent['stereoCategory']['code']
             # Get parent 2
@@ -3473,6 +3473,7 @@ class TestCmpdReg(BaseAcasClientTest):
             # Get the parent again and check out changes were made
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']
+            print(f"DEBUG: parent version: {parent['version']}")
             self.assertEquals(parent['stereoComment'], TEST_STEREO_COMMENT)
             self.assertEquals(parent['stereoCategory']['code'], TEST_STEREO_CAT_CODE)
             # Confirm a non-admin cannot attempt a dry run edit
@@ -3487,11 +3488,10 @@ class TestCmpdReg(BaseAcasClientTest):
             parent['stereoComment'] = ORIG_STEREO_COMMENT
             parent['stereoCategory'] = stereo_cat_dict[ORIG_STEREO_CAT_CODE]
             self.client.edit_parent(parent, dry_run=False)
-            # Sleep for 50 ms to make sure change to the parent has been committed
-            sleep(0.05)
             # Confirm attributes are back to as they were before
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']
+            print(f"DEBUG: parent version: {parent['version']}")
             self.assertEquals(parent['stereoComment'], ORIG_STEREO_COMMENT)
             self.assertEquals(parent['stereoCategory']['code'], ORIG_STEREO_CAT_CODE)
             # Edit structure to match parent 2

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3488,6 +3488,8 @@ class TestCmpdReg(BaseAcasClientTest):
             parent['stereoComment'] = ORIG_STEREO_COMMENT
             parent['stereoCategory'] = stereo_cat_dict[ORIG_STEREO_CAT_CODE]
             edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
+            if not edit_status:
+                print(f"ERROR: Something went wrong editing the parent: {edit_resp}")
             self.assertTrue(edit_status)
             # Confirm attributes are back to as they were before
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3487,7 +3487,8 @@ class TestCmpdReg(BaseAcasClientTest):
             # Edit back to how it was before and save
             parent['stereoComment'] = ORIG_STEREO_COMMENT
             parent['stereoCategory'] = stereo_cat_dict[ORIG_STEREO_CAT_CODE]
-            self.client.edit_parent(parent, dry_run=False)
+            edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
+            self.assertTrue(edit_status)
             # Confirm attributes are back to as they were before
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3,6 +3,7 @@
 """Tests for `acasclient` package."""
 
 from functools import wraps
+from time import sleep
 import unittest
 from acasclient import acasclient
 from pathlib import Path
@@ -3486,6 +3487,8 @@ class TestCmpdReg(BaseAcasClientTest):
             parent['stereoComment'] = ORIG_STEREO_COMMENT
             parent['stereoCategory'] = stereo_cat_dict[ORIG_STEREO_CAT_CODE]
             self.client.edit_parent(parent, dry_run=False)
+            # Sleep for 50 ms to make sure change to the parent has been committed
+            sleep(0.05)
             # Confirm attributes are back to as they were before
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3445,7 +3445,6 @@ class TestCmpdReg(BaseAcasClientTest):
             # Get parent 1
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']
-            print(f"DEBUG: parent version: {parent['version']}")
             ORIG_STEREO_COMMENT = parent['stereoComment']
             ORIG_STEREO_CAT_CODE = parent['stereoCategory']['code']
             # Get parent 2
@@ -3473,7 +3472,6 @@ class TestCmpdReg(BaseAcasClientTest):
             # Get the parent again and check out changes were made
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']
-            print(f"DEBUG: parent version: {parent['version']}")
             self.assertEquals(parent['stereoComment'], TEST_STEREO_COMMENT)
             self.assertEquals(parent['stereoCategory']['code'], TEST_STEREO_CAT_CODE)
             # Confirm a non-admin cannot attempt a dry run edit
@@ -3494,7 +3492,6 @@ class TestCmpdReg(BaseAcasClientTest):
             # Confirm attributes are back to as they were before
             meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
             parent = meta_lot['lot']['parent']
-            print(f"DEBUG: parent version: {parent['version']}")
             self.assertEquals(parent['stereoComment'], ORIG_STEREO_COMMENT)
             self.assertEquals(parent['stereoCategory']['code'], ORIG_STEREO_CAT_CODE)
             # Edit structure to match parent 2


### PR DESCRIPTION
## Description
- Could not reproduce the issue locally, but I'm making a guess that the problem is that the "get_meta_lot" call is happening so soon after the edit_parent call that it hasn't had time to commit the change to the parent. Testing out a fix which is to add a 50ms wait after the edit parent call to give time for the commit to happen before re-fetching the metalot.

## Related Issue

## How Has This Been Tested?
Local tests still pass, but the real test will be on this PR.