### PR TITLE
ACAS-576: add filter for project codes to cmpdreg search

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -377,7 +377,7 @@ class client():
     def cmpd_search(self, corpNameList="", corpNameFrom="", corpNameTo="",
                     aliasContSelect="contains", alias="", dateFrom="",
                     dateTo="", searchType="substructure", percentSimilarity=90,
-                    chemist="anyone", maxResults=100, molStructure=""
+                    chemist="anyone", maxResults=100, molStructure="", projectCodes=None
                     ):
         if isinstance(corpNameList, list):
             corpNameList = ",".join(corpNameList)
@@ -447,6 +447,8 @@ class client():
             search_request["chemist"] = "anyone"
         if("maxResults" not in search_request):
             search_request["maxResults"] = 100
+        if("projectCodes" in search_request and search_request["projectCodes"] is None):
+            del search_request["projectCodes"]
 
         resp = self.session.post("{}/cmpdreg/search/cmpds".
                                  format(self.url),

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -997,6 +997,7 @@ class TestAcasclient(BaseAcasClientTest):
             "percentSimilarity": 90,
             "chemist": "anyone",
             "maxResults": 100,
+            "projectCodes": None,
             "molStructure": (
                 "NSC 1390\n"
                 "\n"
@@ -1101,6 +1102,14 @@ class TestAcasclient(BaseAcasClientTest):
         corp_name_list = ["CMPD-0000001"]
         search_results = self.client.cmpd_search(corpNameList=corp_name_list)
         self.assertGreater(len(search_results["foundCompounds"]), 0)
+        # Filter results by project code
+        search_results = self.client.cmpd_search(
+            corpNameList=corp_name_list, projectCodes=[self.global_project_code])
+        self.assertGreater(len(search_results["foundCompounds"]), 0)
+        # Filter results by project code using fake project code to verify no results
+        search_results = self.client.cmpd_search(
+            corpNameList=corp_name_list, projectCodes=["FAKEPROJECT"])
+        self.assertEqual(len(search_results["foundCompounds"]), 0)
 
 
     @requires_basic_cmpd_reg_load


### PR DESCRIPTION
## Description
Adds the ability to filter cmpdreg searches by project codes

## Related Issue
ACAS-576

## How Has This Been Tested?
acasclient tests