### PR TITLE
ACAS-577: Get all lots and filter by project code

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -401,10 +401,13 @@ class client():
                              % VALID_STRUCTURE_SEARCH_TYPES)
         return self.cmpd_structure_search_request(search_request)
 
-    def get_all_lots(self):
+    def get_all_lots(self, project_codes=None):
         """Get all lots
 
         Get all lots the currently logged in user is allowed to access
+
+        Args:
+            project_codes (list): A list of project codes to filter by
 
         Returns: Returns an array of dict objects
             id (id): the lot corp name
@@ -417,7 +420,13 @@ class client():
         resp = self.session.get("{}/cmpdReg/parentLot/getAllAuthorizedLots"
                                 .format(self.url))
         resp.raise_for_status()
-        return resp.json()
+
+        lots = resp.json()
+
+        if project_codes is not None:
+            lots = [lot for lot in lots if lot["project"] in project_codes]
+        return lots
+
 
     def cmpd_search_request(self, search_request):
         search_request["loggedInUser"] = self.username

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -1701,6 +1701,7 @@ class TestAcasclient(BaseAcasClientTest):
     def test_033_get_all_lots(self):
         """Test get all lots request."""
 
+        # Basic tests of all lots
         all_lots = self.client.get_all_lots()
         self.assertGreater(len(all_lots), 0)
         self.assertIn('id', all_lots[0])
@@ -1709,6 +1710,16 @@ class TestAcasclient(BaseAcasClientTest):
         self.assertIn('parentCorpName', all_lots[0])
         self.assertIn('registrationDate', all_lots[0])
         self.assertIn('project', all_lots[0])
+
+        # Test filter for a specific project
+        # Should return more than 0 lots
+        all_lots_for_project = self.client.get_all_lots([all_lots[0]['project']])
+        self.assertGreater(len(all_lots_for_project), 0)
+        self.assertEquals(all_lots_for_project[0]['project'], all_lots[0]['project'])
+
+        # Should return 0 lots
+        all_lots_for_project = self.client.get_all_lots(['FAKEPROJECT'])
+        self.assertEqual(len(all_lots_for_project), 0)
 
     def test_034_get_ls_things_by_type_and_kind(self):
         codes = []


### PR DESCRIPTION
## Description
 - Simple change to get all lots which allows you to filter by a list of project codes

## Related Issue
ACAS-577

## How Has This Been Tested?
acasclient tests