### PR TITLE
Fixing some imports paths and naming

### DIFF
--- a/acasclient/CmpdReg.py
+++ b/acasclient/CmpdReg.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from acasclient.ddict import ACASDDict
+from .ddict import ACASDDict
 from enum import Enum
 import types
 import logging
-from acasclient import Client
+from .acasclient import client
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -24,7 +24,7 @@ class AdditionalScientist():
         self.name = name
         self.type = type
 
-    def save(self, client: Client) -> AdditionalScientist:
+    def save(self, client: client) -> AdditionalScientist:
         """Save the scientist to the server."""
         if self.type == AdditionalScientistType.COMPOUND:
             resp = client.create_cmpdreg_scientist(self.code, self.name)

--- a/acasclient/experiment.py
+++ b/acasclient/experiment.py
@@ -1,10 +1,11 @@
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from .acasclient import (get_entity_label_by_label_type_kind,
                          get_entity_value_by_state_type_kind_value_type_kind)
 from .selfile import get_file_type, load_from_str
-from acasclient import Client, SimpleExperiment
+from .acasclient import client
+from .selfile import DoseResponse, Generic
 ################################################################################
 # Logging
 ################################################################################
@@ -26,7 +27,7 @@ DELETED_STATUS = "deleted"
 class Experiment(dict):
     """Simple class which adds some convenience methods to an experiment dict to fetch common values and data from the experiment.
     """
-    def __init__(self, expt_dict: dict, client: Optional[Client] = None) -> None:
+    def __init__(self, expt_dict: dict, client: Optional[client] = None) -> None:
         dict.__init__(self, expt_dict)
         # set after source file is written
         self.exported_path = None
@@ -95,7 +96,7 @@ class Experiment(dict):
             value_kind=SOURCE_FILE_KEY)
         return data.get('fileValue') if data else None
 
-    def get_source_file(self, client: Client = None) -> dict:
+    def get_source_file(self, client: client = None) -> dict:
         file = None
         source_file = self.source_file
         if source_file is not None:
@@ -103,7 +104,7 @@ class Experiment(dict):
                         .format(source_file))
         return file
 
-    def get_simple_experiment(self, client=None) -> SimpleExperiment:
+    def get_simple_experiment(self, client=None) -> Union[Generic, DoseResponse]:
         """
         get a simple experiment from the server
         """

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from typing import Any, Dict
 
-from acasclient.ddict import ACASDDict, ACASLsThingDDict, DDict
+from .ddict import ACASDDict, ACASLsThingDDict, DDict
 from .interactions import INTERACTION_VERBS_DICT, opposite
 from .validation import validation_result, ValidationResult
 


### PR DESCRIPTION
## Description
 - The last PR for this issue had a few issues with paths and imports. Honestly not sure how I had it working in my local development environment but may have been some local install overriding what I thought I was using.
 - 

## Related Issue
DISCO-42

## How Has This Been Tested?
Ran import of acasclient using another project and verified it could be imported so the paths and class names are correct now.