### PR TITLE
ACAS-307: Update get_lot_dependencies API

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -2113,7 +2113,24 @@ en array of protocols
                         "comments": "CMPD-0000001-001",
                         "description": "6 results",
                         "ignored": false,
-                        "name": "BLAH"
+                        "name": "BLAH",
+                        "analysisGroups": [
+                            {
+                                "code": "AG-00000001",
+                                "values": [
+                                    {
+                                        "id": 1,
+                                        "lsKind": "key",
+                                        "lsType": "numericValue",
+                                        "value": 6
+                                    }
+                                ]
+                            }
+                        ],
+                        "protocol": {
+                            "code": "PROT-00000001",
+                            "name": "Test Protocol"
+                        }
                     }
                 ],
                 "linkedLots": [

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2853,13 +2853,9 @@ class TestCmpdReg(BaseAcasClientTest):
 
         # Verify the protocol information
         self.assertEqual(len(meta_lot_dependencies['linkedExperiments']), 1)
-        self.assertDictEqual(
-            {
-                'code': 'PROT-00000001',
-                'name': 'BLAH'
-            },
-            meta_lot_dependencies['linkedExperiments'][0]['protocol'],
-        )
+        protocol = meta_lot_dependencies['linkedExperiments'][0]['protocol']
+        self.assertIn('code', protocol)
+        self.assertEqual(protocol['name'], 'BLAH')
 
         # Verify the analysis group information
         self.assertEqual(len(meta_lot_dependencies['linkedExperiments']), 1)

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2851,6 +2851,23 @@ class TestCmpdReg(BaseAcasClientTest):
         # Verify that the experiment code name is in the linkedExperiments list
         self.assertIn(experiment['codeName'], [e['code'] for e in meta_lot_dependencies['linkedExperiments']])
 
+        # Verify the protocol information
+        self.assertEqual(len(meta_lot_dependencies['linkedExperiments']), 1)
+        self.assertDictEqual(
+            {
+                'code': 'PROT-00000001',
+                'name': 'BLAH'
+            },
+            meta_lot_dependencies['linkedExperiments'][0]['protocol'],
+        )
+
+        # Verify the analysis group information
+        self.assertEqual(len(meta_lot_dependencies['linkedExperiments']), 1)
+        item = meta_lot_dependencies['linkedExperiments'][0]['analysisGroups'][0]
+        self.assertIn('code', item)
+        self.assertIn('values', item)
+        self.assertEqual(len(item['values']), 3)
+
         # Delete the experiment and then check the meta lot dependencies again, this time the experiment should be removed from the linkedExperiments list
         self.client.delete_experiment(experiment['id'])
         meta_lot_dependencies = self.client.get_lot_dependencies("CMPD-0000001-001")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update `get_lot_dependencies` API based on the updates in https://github.com/mcneilco/acas/pull/1079.

## Description
<!--- Describe your changes in detail -->
Update docstring and add tests for `get_lot_dependencies`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-307](https://jira.schrodinger.com/browse/ACAS-307)
## How Has This Been Tested?
<!--- Describe how this has been tested -->
Ran existing tests.