### PR TITLE
ACAS-672: Optional alias type and kind to add_parent_alias

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -2278,16 +2278,28 @@ en array of protocols
         aliases = [x['aliasName'] for x in alias_objects if not x['ignored']]
         return aliases
     
-    def add_parent_alias(self, parent_corp_name: str, alias: str) -> None:
+    def add_parent_alias(self, parent_corp_name: str, alias: str, ls_type: str = None, ls_kind: str = None) -> None:
         """Adds a new alias to the specified parent. Does not alter existing aliases.
+
+        Args:
+            parent_corp_name (str): The parent compound to add the alias to
+            alias (str): The alias to add
+            ls_type (str): The LS type of the alias, default None
+            ls_kind (str): The LS kind of the alias, default None
+
+        Returns:
+            The updated MetaLot object
         """
         meta_lot = self._get_meta_lot_by_parent_corp_name(parent_corp_name)
         # Format the alias string into a basic object
-        alias_obj = {'aliasName': alias}
+        alias_obj = {'aliasName': alias, 'lsType': ls_type, 'lsKind': ls_kind, 'ignored': False}
         # Add it to the list of aliases
         meta_lot['lot']['saltForm']['parent']['parentAliases'].append(alias_obj)
         # Persist the change
-        self.save_meta_lot(meta_lot)
+        response = self.save_meta_lot(meta_lot)
+        if len(response['errors']) != 0:
+            raise RuntimeError(f'Failed to add alias {alias} to parent {parent_corp_name}: {response["errors"]}')
+        return response['metalot']
 
     def set_parent_aliases(self, parent_corp_name: str, alias_list: List[str]) -> None:
         """Sets the aliases of the specified parent to ONLY the provided list.

--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -2268,6 +2268,13 @@ en array of protocols
         lot_corp_name = search_results['foundCompounds'][0]['lotIDs'][0]['corpName']
         return self.get_meta_lot(lot_corp_name)
     
+    def get_parent_alias_kinds(self) -> List[Dict]:
+        """Get the list of parent alias kinds
+        """
+        resp = self.session.get("{}/cmpdreg/aliases/parentAliasKinds/".format(self.url))
+        resp.raise_for_status()
+        return resp.json()
+    
     def get_parent_aliases(self, parent_corp_name: str) -> List[str]:
         """Get the current parent aliases by parent_corp_name
         """

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3462,19 +3462,33 @@ class TestCmpdReg(BaseAcasClientTest):
         # Setup constants
         corp_name = "CMPD-0000001"
         alias_1 = "alias-1"
-        test_alias = "TEST-00001"
+        test_alias = str(uuid.uuid4())
 
         # Get aliases
         aliases = self.client.get_parent_aliases(corp_name)
         self.assertEqual(len(aliases), 1)
         self.assertEquals(aliases[0], alias_1)
 
+        # Get parent alias kinds
+        parent_alias_kinds = self.client.get_parent_alias_kinds()
+        self.assertGreater(len(parent_alias_kinds), 0)
+        alias_type = parent_alias_kinds[0]["kindName"]
+        alias_kind = parent_alias_kinds[0]["lsType"]['typeName']
+
         # Add an alias
-        self.client.add_parent_alias(corp_name, test_alias)
+        meta_lot = self.client.add_parent_alias(corp_name, test_alias, alias_type, alias_kind)
         aliases = self.client.get_parent_aliases(corp_name)
         self.assertEqual(len(aliases), 2)
         self.assertIn(alias_1, aliases)
         self.assertIn(test_alias, aliases)
+
+        # Check the metalot and verify that the test_alias with the same type and kind was added
+        parent_aliases = meta_lot["lot"]['saltForm']['parent']['parentAliases']
+        has_test_alias = False
+        for parent_alias in parent_aliases:
+            if parent_alias["aliasName"] == test_alias and parent_alias["lsType"] == alias_type and parent_alias["lsKind"] == alias_kind:
+                has_test_alias = True
+        self.assertTrue(has_test_alias)
 
         # Set the aliases to only the test alias
         self.client.set_parent_aliases(corp_name, [test_alias])


### PR DESCRIPTION
## Description
 - Adds optional type and kind to add_parent_alias

## Related Issue
ACAS-672

## How Has This Been Tested?
Ran acasclient tests
Used the method in some code and verified in the UI that the proper type and kind was set