### PR TITLE
ACAS-701: Add 404 status check for ACAS response for non-existant lot

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -542,7 +542,7 @@ class client():
         """
         resp = self.session.get("{}/cmpdreg/metalots/corpName/{}/"
                                 .format(self.url, lot_corp_name))
-        if resp.status_code == 500:
+        if resp.status_code == 500 or resp.status_code == 404:
             return None
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
## Description
 - Handle case when ACAS returns 404 when fetching non existent lot instead of 500 (500 check kept for backwards compatibility between ACAS client and ACAS base).
 - See https://github.com/mcneilco/acas/pull/1114 for the details

## Related Issue
ACAS-701

## How Has This Been Tested?
Ran ACAS client tests.