### PR TITLE
_get_meta_lot_by_parent_corp_name: Check parent matches searched parent

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -2324,9 +2324,15 @@ en array of protocols
         """
         # Look up the compound to find a lot, so we can access a MetaLot
         search_results = self.cmpd_search(corpNameList=parent_corp_name)
-        if len(search_results['foundCompounds']) == 0:
+
+        found_compounds = search_results['foundCompounds']
+
+        # Return the first found_compound which matches the parent_corp_name
+        found_parent = next((x for x in found_compounds if x['corpName'] == parent_corp_name), None)
+
+        if not found_parent:
             raise RuntimeError(f'Parent corp name {parent_corp_name} could not be found')
-        lot_corp_name = search_results['foundCompounds'][0]['lotIDs'][0]['corpName']
+        lot_corp_name = found_parent['corpName']
         return self.get_meta_lot(lot_corp_name)
     
     def get_parent_alias_kinds(self) -> List[Dict]:

--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -2332,7 +2332,7 @@ en array of protocols
 
         if not found_parent:
             raise RuntimeError(f'Parent corp name {parent_corp_name} could not be found')
-        lot_corp_name = found_parent['corpName']
+        lot_corp_name = found_parent['lotIDs'][0]['corpName']
         return self.get_meta_lot(lot_corp_name)
     
     def get_parent_alias_kinds(self) -> List[Dict]:


### PR DESCRIPTION
## Description
**To reproduce**
Upload several compounds to ACAS
Call e.g. add_parent_alias("CMPD-00001", "myalias") to add the alias


**Expectation**
add_parent_alias adds the "myalias" to parent compound "CMPD-00001"

**Actual outcome**
add_parent_alias can add the alias to the wrong parent if more than one parent is returned from a list ID search for that compound.

**Details**
self.cmpd_search(corpNameList=parent_corp_name) for e.g. CMPD-000001 can return results for CMPD-0000001, CMPD-000000010, CMPD-000000100 and more.
The function just picks the first parent and adds the alias to it so if by change CMPD-0000100 is returned, it gets the alias.

## Related Issue
ACAS-717

## How Has This Been Tested?
On a system running ACAS 2023.2.0 we verified that this fix works and set the proper parent alias
I verified our tests did test add, get and set aliases and that the affected function was not used beyond those use cases so did not affect other parts of acasclient.
I did not try and reproduce the issue with test client as I think that test could end up being very flakey.