### PR TITLE
Add test for vendorID updates

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3216,12 +3216,15 @@ class TestCmpdReg(BaseAcasClientTest):
 
         # Verify our cmpdreg admin user can save the restricted lot
         meta_lot["lot"]["color"] = "red"
+        VENDOR_ID = "12345"
+        meta_lot["lot"]["vendorID"] = VENDOR_ID
         response = self.client.\
             save_meta_lot(meta_lot)
         self.assertEqual(len(response["errors"]), 0)
         self.assertIn("metalot", response)
         self.assertIn("lot", response["metalot"])
         self.assertEqual(response["metalot"]["lot"]["color"], "red")
+        self.assertEqual(response["metalot"]["lot"]["vendorID"], VENDOR_ID)
         self.assertIsNotNone(response["metalot"]["lot"]["modifiedDate"])  # Lot is modified
 
         # Verify our admin user can update the project


### PR DESCRIPTION
## Description
 - Adds test for meta lot vendorID updates. See changes on https://github.com/mcneilco/acas-roo-server/pull/453

## Related Issue
https://jira.schrodinger.com/browse/ACAS-696

## How Has This Been Tested?
Ran acasclient tests and verified manually that vendorID updates persist
