### PR TITLE
Fix automated test for author roles

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -2069,10 +2069,12 @@ class TestAcasclient(BaseAcasClientTest):
         role = updated_author['authorRoles'][0]['roleEntry']
         self.assertEqual(role['roleName'], 'ROLE_ACAS-USERS')
         # Try adding a role by updating the author
-        # Unfortunately we need to hardcode the id of the role, or fetch it from the server
+        # We need to fetch the lsRole id from the server
+        ls_roles = self.client.session.get(self.client.url + '/api/lsRoles/codeTable').json()
+        cmpdreg_role_id = [role for role in ls_roles if role['code'] == 'System_CmpdReg_ROLE_CMPDREG-USERS'][0]['id']
         nested_cmpdreg_role = {
             'roleEntry': {
-                'id': 3,
+                'id': cmpdreg_role_id,
                 'lsType': 'System',
                 'lsKind': 'CmpdReg',
                 'roleName': 'ROLE_CMPDREG-USERS',


### PR DESCRIPTION
## Description
In the existing test I had hardcoded an id. That id no longer refers to the same object as I expected so the test fails.
I've replaced it with a better approach where I look up the id.

## Related Issue

## How Has This Been Tested?
Tested locally that the acasclient test was failing, and is fixed after this change.