### PR TITLE
Attempted fixes for flaky tests

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -288,6 +288,12 @@ def delete_all_lots_and_experiments(self):
     if len(lots) > 0:
         self.delete_all_experiments()
         self.delete_all_cmpd_reg_bulk_load_files()
+        # Check lots again
+        lots = self.client.get_all_lots()
+        if len(lots) > 0:
+            # Delete any remaining lots not from bulk loads
+            for lot in lots:
+                self.client.delete_lot(lot['lotCorpName'])
 
 def requires_basic_cmpd_reg_load(func):
     """

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3792,54 +3792,54 @@ class TestCmpdReg(BaseAcasClientTest):
             self.assertEquals(validation_resp[0]['code'], 'CMPD-0000001-001')
             self.assertEquals(validation_resp[0]['name'], 'CMPD-0000001-001')
             # TODO Get this working reliably and uncomment it
-            # # Commit the edit
-            # edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
-            # # Confirm edit response mentions the lot
-            # self.assertTrue(edit_status)
-            # self.assertEquals(len(edit_resp), 1)
-            # self.assertEquals(edit_resp[0]['code'], 'CMPD-0000001-001')
-            # self.assertEquals(edit_resp[0]['name'], 'CMPD-0000001-001')
-            # # Get the parent again and check out changes were made
-            # meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
-            # parent = meta_lot['lot']['parent']
-            # self.assertEquals(parent['stereoComment'], TEST_STEREO_COMMENT)
-            # self.assertEquals(parent['stereoCategory']['code'], TEST_STEREO_CAT_CODE)
-            # # Confirm a non-admin cannot attempt a dry run edit
-            # with self.assertRaises(requests.HTTPError) as context:
-            #     cmpdreg_user.edit_parent(parent, dry_run=True)
-            # self.assertIn('401 Client Error: Unauthorized for url', str(context.exception))
-            # # Confirm a non-admin cannot edit
-            # with self.assertRaises(requests.HTTPError) as context:
-            #     cmpdreg_user.edit_parent(parent, dry_run=False)
-            # self.assertIn('401 Client Error: Unauthorized for url', str(context.exception))
-            # # Edit back to how it was before and save
-            # parent['stereoComment'] = ORIG_STEREO_COMMENT
-            # parent['stereoCategory'] = stereo_cat_dict[ORIG_STEREO_CAT_CODE]
-            # edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
-            # if not edit_status:
-            #     print(f"ERROR: Something went wrong editing the parent: {edit_resp}")
-            # self.assertTrue(edit_status)
-            # # Confirm attributes are back to as they were before
-            # meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
-            # parent = meta_lot['lot']['parent']
-            # self.assertEquals(parent['stereoComment'], ORIG_STEREO_COMMENT)
-            # self.assertEquals(parent['stereoCategory']['code'], ORIG_STEREO_CAT_CODE)
-            # # Edit structure to match parent 2
-            # # This should result in a duplicate, and thus be blocked
-            # parent['molStructure'] = CMPD_2_STRUCTURE
-            # # Validate (should fail)
-            # validation_status, validation_resp = self.client.edit_parent(parent, dry_run=True)
-            # self.assertFalse(validation_status)
-            # self.assertFalse(validation_resp['parentUnique'])
-            # self.assertEquals(len(validation_resp['dupeParents']), 1)
-            # self.assertEquals(validation_resp['dupeParents'][0]['corpName'], 'CMPD-0000002')
-            # # Attempt non-dryrun (should fail)
-            # edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
-            # self.assertFalse(edit_status)
-            # self.assertFalse(edit_status)
-            # self.assertFalse(edit_resp['parentUnique'])
-            # self.assertEquals(len(edit_resp['dupeParents']), 1)
-            # self.assertEquals(edit_resp['dupeParents'][0]['corpName'], 'CMPD-0000002')
+            # Commit the edit
+            edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
+            # Confirm edit response mentions the lot
+            self.assertTrue(edit_status)
+            self.assertEquals(len(edit_resp), 1)
+            self.assertEquals(edit_resp[0]['code'], 'CMPD-0000001-001')
+            self.assertEquals(edit_resp[0]['name'], 'CMPD-0000001-001')
+            # Get the parent again and check out changes were made
+            meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
+            parent = meta_lot['lot']['parent']
+            self.assertEquals(parent['stereoComment'], TEST_STEREO_COMMENT)
+            self.assertEquals(parent['stereoCategory']['code'], TEST_STEREO_CAT_CODE)
+            # Confirm a non-admin cannot attempt a dry run edit
+            with self.assertRaises(requests.HTTPError) as context:
+                cmpdreg_user.edit_parent(parent, dry_run=True)
+            self.assertIn('401 Client Error: Unauthorized for url', str(context.exception))
+            # Confirm a non-admin cannot edit
+            with self.assertRaises(requests.HTTPError) as context:
+                cmpdreg_user.edit_parent(parent, dry_run=False)
+            self.assertIn('401 Client Error: Unauthorized for url', str(context.exception))
+            # Edit back to how it was before and save
+            parent['stereoComment'] = ORIG_STEREO_COMMENT
+            parent['stereoCategory'] = stereo_cat_dict[ORIG_STEREO_CAT_CODE]
+            edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
+            if not edit_status:
+                print(f"ERROR: Something went wrong editing the parent: {edit_resp}")
+            self.assertTrue(edit_status)
+            # Confirm attributes are back to as they were before
+            meta_lot = self.client.get_meta_lot('CMPD-0000001-001')
+            parent = meta_lot['lot']['parent']
+            self.assertEquals(parent['stereoComment'], ORIG_STEREO_COMMENT)
+            self.assertEquals(parent['stereoCategory']['code'], ORIG_STEREO_CAT_CODE)
+            # Edit structure to match parent 2
+            # This should result in a duplicate, and thus be blocked
+            parent['molStructure'] = CMPD_2_STRUCTURE
+            # Validate (should fail)
+            validation_status, validation_resp = self.client.edit_parent(parent, dry_run=True)
+            self.assertFalse(validation_status)
+            self.assertFalse(validation_resp['parentUnique'])
+            self.assertEquals(len(validation_resp['dupeParents']), 1)
+            self.assertEquals(validation_resp['dupeParents'][0]['corpName'], 'CMPD-0000002')
+            # Attempt non-dryrun (should fail)
+            edit_status, edit_resp = self.client.edit_parent(parent, dry_run=False)
+            self.assertFalse(edit_status)
+            self.assertFalse(edit_status)
+            self.assertFalse(edit_resp['parentUnique'])
+            self.assertEquals(len(edit_resp['dupeParents']), 1)
+            self.assertEquals(edit_resp['dupeParents'][0]['corpName'], 'CMPD-0000002')
         finally:
             # Prevent interaction with other tests.
             self.delete_all_cmpd_reg_bulk_load_files()


### PR DESCRIPTION
## Description
Observed two phenotypes of test failures:
- https://github.com/mcneilco/acas/actions/runs/6909971925/job/18802300896 where the SDF load for SEL fails with a mismatched corp names error, as if a compound has been left in the system when we try to re-load the basic file
- https://github.com/mcneilco/acas/actions/runs/6910041295/job/18802488125 where the edit parent test fails trying to fetch one of the metalots

I'd like to test out a fix for the first issue which is a more aggressive deletion of lots when the expected lots aren't found.
I'm really not sure the cause of the edit parent failure, but I want to investigate it further so I've uncommented the rest of the edit parent test to try to catch it failing when the tests run.

## Related Issue

## How Has This Been Tested?
- Ran acasclient tests locally, but the real test will come from running & re-running in GHA