### PR TITLE
Add handling for new chemist attribute in parentLot/getAllAuthorizedLots route 

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -627,6 +627,7 @@ class client():
             parentCorpName (str): the lots parent corp name
             registrationDate (int): the registration date
             project (str): the lots project
+            chemist (str): the lots chemist
         """
         resp = self.session.get("{}/cmpdReg/parentLot/getAllAuthorizedLots"
                                 .format(self.url))

--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -628,6 +628,9 @@ class client():
             registrationDate (int): the registration date
             project (str): the lots project
             chemist (str): the lots chemist
+            supplier (str): the lots supplier
+            vendorName (str): the lots vendor name
+            vendorCode (str): the lots vendor code
         """
         resp = self.session.get("{}/cmpdReg/parentLot/getAllAuthorizedLots"
                                 .format(self.url))

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -1905,6 +1905,9 @@ class TestAcasclient(BaseAcasClientTest):
         self.assertIn('registrationDate', all_lots[0])
         self.assertIn('project', all_lots[0])
         self.assertIn('chemist', all_lots[0])
+        self.assertIn('supplier', all_lots[0])
+        self.assertIn('vendorName', all_lots[0])
+        self.assertIn('vendorCode', all_lots[0])
 
         # Test filter for a specific project
         # Should return more than 0 lots

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -1904,6 +1904,7 @@ class TestAcasclient(BaseAcasClientTest):
         self.assertIn('parentCorpName', all_lots[0])
         self.assertIn('registrationDate', all_lots[0])
         self.assertIn('project', all_lots[0])
+        self.assertIn('chemist', all_lots[0])
 
         # Test filter for a specific project
         # Should return more than 0 lots


### PR DESCRIPTION
## Description
Users requested including lot chemist as an attribute for each record in creg metadata when calling the cmpdReg/parentLot/getAllAuthorizedLots endpoint with the goal of helping analyze and categorize records by using lot chemist.

After updating backend, added docstring and test to check for the new attribute in related acasclient functions. 