### PR TITLE
ACAS-536: Update Github Actions dependencies

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -10,9 +10,9 @@ jobs:
   acasclient:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup python 3.8
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
       - name: Install pypa/build and twine

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout acasclient
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: acasclient
       - name: Set Up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Display Python version
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "ACAS_TAG=$(echo ${{ env.ACAS_REF }} | sed 's/\//-/g')" >> $GITHUB_ENV
       - name: Checkout ACAS
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: mcneilco/acas
           path: acas


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Update Github Action to avoid deprecation warnings

## Related Issue
ACAS-536

## How Has This Been Tested?
 - `Launch ACAS and run python tests` 
   - No warnings now:  https://github.com/mcneilco/acasclient/actions/runs/9422067783
   - Before changes: https://github.com/mcneilco/acasclient/actions/runs/9420638308
```
Annotations
2 warnings
acas
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
acas
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-python@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

 - `Build and Publish` 
   - No warnings now: https://github.com/mcneilco/acasclient/actions/runs/9422058090
   - Before changes: https://github.com/mcneilco/acas-roo-server/actions/runs/9421219674
```
Annotations
2 warnings
acasclient
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-python@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
acasclient
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```