### PR TITLE
Add ls_kinds property

### DIFF
--- a/acasclient/experiment.py
+++ b/acasclient/experiment.py
@@ -87,6 +87,15 @@ class Experiment(dict):
         return protocol_name["labelText"]
 
     @property
+    def ls_kinds(self) -> list:
+        data = get_entity_values_by_state_type_kind_value_type(
+                entity=self,
+                state_type="metadata",
+                state_kind="data column order",
+                value_type="codeValue")
+        return [d['codeValue'] for d in data if d['codeKind'] == 'column name']
+
+    @property
     def project(self) -> None:
         prj = get_entity_value_by_state_type_kind_value_type_kind(
                 entity=self,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Adds ls_kinds property to experiment object which fetches the list of ls_kind from the experiment data columns experiment value.
 
## Related Issue
DISCO_1468

## How Has This Been Tested?
 - Ran the code using an ETL script which uses the information to detect when an experiment ls_kind exists.