### PR TITLE
DISCO-1674: column_information, result_types, is_images_file_experiment, image zip bug fixes

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: |
           python -m build --sdist --wheel --outdir dist/ .
-      - name: Publish to TestPyPI
-        run: |
-          python -m twine upload --skip-existing -u ${{ secrets.TEST_PYPI_USERNAME }} -p ${{ secrets.TEST_PYPI_PASSWORD }} --repository-url https://test.pypi.org/legacy/ dist/*
+      # - name: Publish to TestPyPI
+      #   run: |
+      #     python -m twine upload --skip-existing -u ${{ secrets.TEST_PYPI_USERNAME }} -p ${{ secrets.TEST_PYPI_PASSWORD }} --repository-url https://test.pypi.org/legacy/ dist/*
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,11 +43,11 @@ jobs:
           repository: mcneilco/acas
           path: acas
           ref: ${{ env.ACAS_REF }}
-      - name: Run docker-compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
+      - name: Run docker compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
         id: dockerComposeUp
         working-directory: acas
         run: |
-          docker-compose -f "docker-compose.yml" up -d
+          docker compose -f "docker-compose.yml" up -d
       - name: Wait for startup then create docker bob
         run: bash docker_bob_setup.sh
         working-directory: acas

--- a/acasclient/experiment.py
+++ b/acasclient/experiment.py
@@ -123,11 +123,6 @@ class Experiment(dict):
 
     @property
     def result_kinds(self) -> list:
-        data = get_entity_values_by_state_type_kind_value_type(
-                entity=self,
-                state_type="metadata",
-                state_kind="data column order",
-                value_type="codeValue")
         return [d['codeValue'] for d in self.column_information if d['codeKind'] == 'column name']
 
     @property

--- a/acasclient/experiment.py
+++ b/acasclient/experiment.py
@@ -58,7 +58,7 @@ def fetch_analysis_groups_if_missing(func):
         return func(self, *args, **kwargs)
     return wrapper
 
-def fetch_analysis_groups_if_images_expertiment(func):
+def fetch_analysis_groups_if_images_experiment(func):
     """Decorator to fetch analysis groups if they are missing from the experiment dict
     """
     @wraps(func)
@@ -170,7 +170,7 @@ class Experiment(dict):
     def is_images_file_experiment(self) -> bool:
         return IMAGES_FILE_RESULT_TYPE in self.result_types
 
-    @fetch_analysis_groups_if_images_expertiment
+    @fetch_analysis_groups_if_images_experiment
     def get_images_file(self, client: client = None) -> str:
         """Get a zip file of all the image (inline file values) in the experiment
         The zip image file isn't saved as a file in the experiment, but rather each image file is saved as an analysis group value. This method fetches all the image files and creates a zip file with them.

--- a/acasclient/experiment.py
+++ b/acasclient/experiment.py
@@ -26,6 +26,7 @@ SOURCE_FILE_KEY = "source file"
 REPORT_FILE_KEY = "annotation file"
 DELETED_STATUS = "deleted"
 ANALYSIS_GROUPS_KEY = "analysisGroups"
+IMAGES_FILE_RESULT_TYPE = "inlineFileValue"
 ################################################################################
 # Classes
 ################################################################################
@@ -36,10 +37,35 @@ def fetch_analysis_groups_if_missing(func):
     """
     @wraps(func)
     def wrapper(self, *args, **kwargs):
+        # Check if 'client' is in kwargs
+        aclient = kwargs.get('client', None)
+        
+        # If 'client' is not in kwargs, check if it's in args
+        if aclient is None:
+            for arg in args:
+                if isinstance(arg, client):
+                    aclient = arg
+                    break
+        
+        if aclient is None:
+            if self.client is None:
+                raise Exception("No client provided and no client found in the experiment")
+            aclient = self.client
+        
         if ANALYSIS_GROUPS_KEY not in self:
-            experiment_dict = self.client.get_experiment_by_code(self.code, full=True)
-            self.__init__(experiment_dict, client=self.client)
-        return func(self)
+            experiment_dict = aclient.get_experiment_by_code(self.code, full=True)
+            self[ANALYSIS_GROUPS_KEY] = experiment_dict[ANALYSIS_GROUPS_KEY]
+        return func(self, *args, **kwargs)
+    return wrapper
+
+def fetch_analysis_groups_if_images_expertiment(func):
+    """Decorator to fetch analysis groups if they are missing from the experiment dict
+    """
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if self.is_images_file_experiment:
+            return fetch_analysis_groups_if_missing(func)(self, *args, **kwargs)
+        return func(self, *args, **kwargs)
     return wrapper
 
 class Experiment(dict):
@@ -87,13 +113,26 @@ class Experiment(dict):
         return protocol_name["labelText"]
 
     @property
+    def column_information(self) -> list:
+        data = get_entity_values_by_state_type_kind_value_type(
+                entity=self,
+                state_type="metadata",
+                state_kind="data column order",
+                value_type="codeValue")
+        return data
+
+    @property
     def result_kinds(self) -> list:
         data = get_entity_values_by_state_type_kind_value_type(
                 entity=self,
                 state_type="metadata",
                 state_kind="data column order",
                 value_type="codeValue")
-        return [d['codeValue'] for d in data if d['codeKind'] == 'column name']
+        return [d['codeValue'] for d in self.column_information if d['codeKind'] == 'column name']
+
+    @property
+    def result_types(self) -> list:
+        return [d['codeValue'] for d in self.column_information if d['codeKind'] == 'column type']
 
     @property
     def project(self) -> None:
@@ -127,7 +166,11 @@ class Experiment(dict):
                         .format(source_file))
         return file
     
-    @fetch_analysis_groups_if_missing
+    @property
+    def is_images_file_experiment(self) -> bool:
+        return IMAGES_FILE_RESULT_TYPE in self.result_types
+
+    @fetch_analysis_groups_if_images_expertiment
     def get_images_file(self, client: client = None) -> str:
         """Get a zip file of all the image (inline file values) in the experiment
         The zip image file isn't saved as a file in the experiment, but rather each image file is saved as an analysis group value. This method fetches all the image files and creates a zip file with them.
@@ -136,17 +179,27 @@ class Experiment(dict):
             str: The path to the zip file or None if there are no images in the experiment
         """
 
+        if not self.is_images_file_experiment:
+            return None
+
         # Loop through all the analysis groups and get the inline file values and add them to a set
-        analysisGroups = self["analysisGroups"]
+        analysisGroups = self[ANALYSIS_GROUPS_KEY]
         inlineFilePaths = set()
         for ag in analysisGroups:
-            inlineFileValues = get_entity_values_by_state_type_kind_value_type(ag, "data", "results", "inlineFileValue")
+            inlineFileValues = get_entity_values_by_state_type_kind_value_type(ag, "data", "results", IMAGES_FILE_RESULT_TYPE)
             for inlineFileValue in inlineFileValues:
-                inlineFilePaths.add(inlineFileValue['fileValue'])
+                if 'fileValue' in inlineFileValue:
+                    inlineFilePaths.add(inlineFileValue['fileValue'])
 
         # If there are no inline file values, return None
         if len(inlineFilePaths) == 0:
             return None
+
+        # Check if there is a client and fall back to self.client or raise an exception
+        if client is None:
+            if self.client is None:
+                raise Exception("No client provided and no client found in the experiment")
+            client = self.client
         
         # Create a unique zip file name
         images_file_to_upload = tempfile.NamedTemporaryFile(suffix=".zip").name
@@ -155,7 +208,7 @@ class Experiment(dict):
         with zipfile.ZipFile(images_file_to_upload, 'w') as zip_ref:
             for inlineFilePath in inlineFilePaths:
                 # Fetch the file from the API
-                file = self.client.get_file("/dataFiles/{}"
+                file = client.get_file("/dataFiles/{}"
                                     .format(inlineFilePath))
                 # Write the file to base directory of the zip
                 zip_ref.writestr(file["name"], file["content"])

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -19,6 +19,7 @@ from acasclient.experiment import Experiment
 from acasclient.acasclient import (get_entity_value_by_state_type_kind_value_type_kind)
 import zipfile
 from acasclient.selfile import Generic
+from collections import Counter
 
 # Import project ls thing
 from datetime import datetime
@@ -487,6 +488,16 @@ class BaseAcasClientTest(unittest.TestCase):
             source_file = experiment.get_source_file()
             self.verify_file_and_content_equal(data_file_to_upload, source_file['content'])
 
+            # Ensure that column_information exists and is a list
+            self.assertIsInstance(experiment.column_information, list)
+
+            # Ensure that specific entries exist in column_information
+            lsKind_counts = Counter(col_info['lsKind'] for col_info in experiment.column_information)
+            self.assertEqual(lsKind_counts['condition column'], lsKind_counts['column type'])
+            self.assertEqual(lsKind_counts['condition column'], lsKind_counts['column name'])
+            self.assertEqual(lsKind_counts['condition column'], lsKind_counts['column units'])
+            self.assertEqual(lsKind_counts['condition column'], lsKind_counts['hide column'])
+
             if report_file_to_upload is not None:
                 report_file = experiment.get_report_file()
 
@@ -505,6 +516,12 @@ class BaseAcasClientTest(unittest.TestCase):
                 # Use simple experiment to read the file we uploaded
                 simple_experiment = Generic()
                 simple_experiment.loadFile(data_file_to_upload)
+
+                # Make sure is_images_file_experiment is set to True
+                self.assertTrue(experiment.is_images_file_experiment)
+
+                # Make sure that inlineFileValue in result_types
+                self.assertIn("inlineFileValue", experiment.result_types)
                 
                 # Loop through the simple_experiment._datatype  and if the value is "Image File" then get the key of the image file (lsType)
                 image_file_kinds = [k for k, v in simple_experiment._datatype.items() if v == "Image File"]


### PR DESCRIPTION
## Description
 - This adds new functionality to the experiment object
   - `column_information` property to get all column information for an experiment
   - `result_types` property to get just the result types from the column information
   - `is_images_file_experiment` to check if inline file value result types were uploaded to the experiment
 - Speeds up creating an image file zip by first checking if the experiment is an image file experiment.
 - Fixes a bug where the client passed into the get_images_file function is not used.

## Related Issue
[DISCO-1674](https://schrodinger.atlassian.net/browse/DISCO-1674)

## How Has This Been Tested?
Added and ran acasclient tests