### PR TITLE
ACAS-797: Fix error when code_origin is explicitly None

### DIFF
--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -2154,7 +2154,7 @@ class SimpleLsThing(BaseModel):
         for state_dict in state_dicts:
             for values_dict in state_dict.values():
                 for value in values_dict.values():
-                    if isinstance(value, CodeValue):
+                    if isinstance(value, CodeValue) and value.code_origin:
                         ddict = None
                         if value.code_origin.upper() == ACAS_DDICT:
                             ddict = ACASDDict(value.code_type, value.code_kind)
@@ -2170,6 +2170,7 @@ class SimpleLsThing(BaseModel):
     @validation_result
     def _validate_codevalues(self, ddicts):
         """Confirm all CodeValues have valid values.
+        Note: validation is skipped if a CodeValue's code_origin is None
 
         :param ddicts: dict of (code_type, code_kind, code_origin): DDict. Should come from _get_ddicts()
         :type ddicts: dict
@@ -2180,7 +2181,7 @@ class SimpleLsThing(BaseModel):
             for values_dict in state_dict.values():
                 for value in values_dict.values():
                     if isinstance(value, CodeValue):
-                        if value.code:
+                        if value.code and value.code_origin:
                             # Get the corresponding DDict
                             ddict = ddicts.get((value.code_type, value.code_kind, value.code_origin.upper()), None)
                             if ddict:

--- a/acasclient/lsthing.py
+++ b/acasclient/lsthing.py
@@ -1001,10 +1001,11 @@ class CodeValue(object):
             self.code_kind = code_kind
             self.code_origin = code_origin
             # Auto-recognize some code origin:
-            if self.code_origin.upper() == ACAS_DDICT:
-                self.ddict = ACASDDict(code_type, code_kind)
-            elif self.code_origin.upper() == ACAS_LSTHING:
-                self.ddict = ACASLsThingDDict(code_type, code_kind)
+            if self.code_origin:
+                if self.code_origin.upper() == ACAS_DDICT:
+                    self.ddict = ACASDDict(code_type, code_kind)
+                elif self.code_origin.upper() == ACAS_LSTHING:
+                    self.ddict = ACASLsThingDDict(code_type, code_kind)
 
     def __hash__(self):
         return hash(f'{self.code}-{self.code_type}-{self.code_kind}-'

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -980,6 +980,23 @@ class TestCodeValue(BaseAcasClientTest):
         code_value = CodeValue(code=code, code_type=None, code_kind=None, code_origin=None)
         assert code_value.code == code
         assert code_value.code_origin is None
+        # Construct a basic SimpleLsThing object and save it
+        name = str(uuid.uuid4())
+        meta_dict = {
+            NAME_KEY: name,
+            IS_RESTRICTED_KEY: True,
+            STATUS_KEY: ACTIVE,
+            START_DATE_KEY: datetime.now()
+        }
+        newProject = Project(recorded_by=self.client.username, **meta_dict)
+        # Override the status with the CodeValue with null code_origin
+        # Confirm this bypasses CodeValue validation
+        newProject.metadata[PROJECT_METADATA][PROJECT_STATUS] = code_value
+        newProject.save(self.client)
+        # Fetch the project and confirm the CodeValue is as expected (code_origin should be None)
+        fresh_project = Project.get_by_code(newProject.code_name, self.client, Project.ls_type, Project.ls_kind)
+        assert fresh_project.metadata[PROJECT_METADATA][PROJECT_STATUS].code == code
+        assert fresh_project.metadata[PROJECT_METADATA][PROJECT_STATUS].code_origin is None
 
 class TestValidationResponse(BaseAcasClientTest):
 

--- a/tests/test_lsthing.py
+++ b/tests/test_lsthing.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from acasclient.ddict import ACASDDict, ACASLsThingDDict
 from acasclient.lsthing import (BlobValue, CodeValue, FileValue, LsThingValue,
-                                SimpleLsThing, get_lsKind_to_lsvalue, datetime_to_ts, LsThing)
+                                SimpleLsThing, get_lsKind_to_lsvalue, datetime_to_ts, LsThing, ACAS_DDICT)
 from acasclient.validation import ValidationResult, get_validation_response
 from acasclient.protocol import Protocol
 from tests.test_acasclient import BaseAcasClientTest
@@ -969,6 +969,17 @@ class TestBlobValue(BaseAcasClientTest):
         assert blob_value_dict['value'] == value
         assert blob_value_dict['comments'] == comments
         assert blob_value_dict['id'] == id
+
+class TestCodeValue(BaseAcasClientTest):
+
+    def test_instantiation_without_code_origin(self):
+        """
+        Verify that CodeValue can be instantiated without a code_origin.
+        """
+        code = "1234"
+        code_value = CodeValue(code=code, code_type=None, code_kind=None, code_origin=None)
+        assert code_value.code == code
+        assert code_value.code_origin is None
 
 class TestValidationResponse(BaseAcasClientTest):
 


### PR DESCRIPTION
## Description
Custom ACAS code is running into errors with latest acasclient where some CodeValues are being instantiated from ls_value objects with null / None code_origin. While unexpected, we should allow this at the acasclient level.

## Related Issue

## How Has This Been Tested?
- Wrote automated test, confirmed error, then fixed it

## Extra Information
I'm planning to tag a new release of acasclient (`2024.4.0`) after merging this.