### PR TITLE
ACAS-841: acasclient selfile Generic parser fails to properly parse SEL file with Custom Experiment Metadata 

### DIFF
--- a/acasclient/selfile.py
+++ b/acasclient/selfile.py
@@ -173,7 +173,7 @@ class AbstractExperiment():
     VALID_DATATYPES = set(VALID_DATATYPES)
 
     blank = ""
-    _meta_rows = 15  # Scan this many rows for the end of meta/start of payload.
+    _meta_rows = 50  # Scan this many rows for the end of meta/start of payload.
 
     def __init__(self, file_name=None):
         """

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -4922,3 +4922,15 @@ class TestExperimentLoader(BaseAcasClientTest):
             }
         ]
         self.check_expected_messages(expected_messages, response['errorMessages'])
+        
+    @requires_basic_cmpd_reg_load
+    def test_021_experiment_with_custom_metadata(self):
+        """Test experiment loader number with custom experiment metadata"""
+        data_file_to_upload = Path(__file__).resolve()\
+            .parent.joinpath('test_acasclient', 'experiment_with_custom_meta_data.csv')
+        response = self.experiment_load_test(data_file_to_upload, False, expect_failure=False)
+        assert response['results']['experimentCode'] is not None
+        experiment = self.client.\
+            get_experiment_by_code(response['results']['experimentCode'], full = True)
+        self.assertIsNotNone(experiment)
+        self.assertIn("analysisGroups", experiment)

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -4922,15 +4922,18 @@ class TestExperimentLoader(BaseAcasClientTest):
             }
         ]
         self.check_expected_messages(expected_messages, response['errorMessages'])
-        
+    
     @requires_basic_cmpd_reg_load
     def test_021_experiment_with_custom_metadata(self):
-        """Test experiment loader number with custom experiment metadata"""
+        """Test selfile Generic parser with custom experiment metadata"""
         data_file_to_upload = Path(__file__).resolve()\
             .parent.joinpath('test_acasclient', 'experiment_with_custom_meta_data.csv')
-        response = self.experiment_load_test(data_file_to_upload, False, expect_failure=False)
-        assert response['results']['experimentCode'] is not None
-        experiment = self.client.\
-            get_experiment_by_code(response['results']['experimentCode'], full = True)
+        experiment = Generic()
+        experiment.loadFile(data_file_to_upload)
+        temp_file_path = Path(tempfile.gettempdir()) / f"{experiment.name}.csv"
+        experiment.saveAs(temp_file_path)
+        response = self.experiment_load_test(temp_file_path, False, expect_failure=False)
+        assert response['hasError'] is False
+        experiment = self.client.get_experiment_by_name(experiment.name)
         self.assertIsNotNone(experiment)
         self.assertIn("analysisGroups", experiment)

--- a/tests/test_acasclient/experiment_with_custom_meta_data.csv
+++ b/tests/test_acasclient/experiment_with_custom_meta_data.csv
@@ -1,0 +1,19 @@
+Experiment Meta Data,,
+Format,Generic,
+Protocol Name,Toxicity,
+Experiment Name,Toxicity Screen 1,
+Scientist,bob,
+Notebook,Main Experimental Notebook,
+Page,Main Experimental Notebook Page 1,
+Assay Date,2025-02-01,
+Project,Global,
+,,
+Custom Experiment Meta Data,,
+CRO,Pharmaron,Select List
+Jira Link,https://mycompany.jira.com/browse/JIRA-1,URL
+Jira Issue,JIRA-1,Text
+,,
+Calculated Results,,
+Datatype,Number,Number
+Corporate Batch ID,t1/2 (min),In vitro Clint (µL/min/mg protein)
+CMPD-0000001-001,2.67,42.8

--- a/tests/test_acasclient/experiment_with_custom_meta_data.csv
+++ b/tests/test_acasclient/experiment_with_custom_meta_data.csv
@@ -12,6 +12,8 @@ Custom Experiment Meta Data,,
 CRO,Pharmaron,Select List
 Jira Link,https://mycompany.jira.com/browse/JIRA-1,URL
 Jira Issue,JIRA-1,Text
+Priority,High,Text
+Comment,BlahBlah,Text
 ,,
 Calculated Results,,
 Datatype,Number,Number


### PR DESCRIPTION
## Description

[Jira Ticket
](https://schrodinger.atlassian.net/browse/ACAS-841)
**Steps to Reproduce:** 

Use the acasclient selfile Generic class to parse an SEL file with Custom Experiment Metadata section and several custom properties.

**Expected Results:** 

File can be parsed

**Actual Results:** 

Header block is not parsed correctly and the stacktrace below occurs

**Extra Information**

See ticket details  

## How Has This Been Tested?

Ran `python -m unittest tests.test_acasclient.TestExperimentLoader.test_021_experiment_with_custom_metadata ` 