### PR TITLE
Fix master branch test failures of test_021_experiment_with_custom_metadata

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -4934,6 +4934,6 @@ class TestExperimentLoader(BaseAcasClientTest):
         experiment.saveAs(temp_file_path)
         response = self.experiment_load_test(temp_file_path, False, expect_failure=False)
         assert response['hasError'] is False
-        experiment = self.client.get_experiment_by_name(experiment.name)
+        experiment = self.client.get_experiment_by_code(response['results']['experimentCode'], full = True)
         self.assertIsNotNone(experiment)
         self.assertIn("analysisGroups", experiment)


### PR DESCRIPTION
## Description

[Jira Ticket](https://schrodinger.atlassian.net/browse/ACAS-869)

The ACAS builds on master are failing.  Example: [Merge pull request #1214 from mcneilco/release/2025.2.x · mcneilco/acas@3b03607](https://github.com/mcneilco/acas/actions/runs/14499824874/job/40686692836) 

Example error:

```
======================================================================
FAIL: test_021_experiment_with_custom_metadata (tests.test_acasclient.TestExperimentLoader)
Test selfile Generic parser with custom experiment metadata
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/acas/acas/acasclient/tests/test_acasclient.py", line 314, in wrapper
    return func(self)
  File "/home/runner/work/acas/acas/acasclient/tests/test_acasclient.py", line 4939, in test_021_experiment_with_custom_metadata
    self.assertIn("analysisGroups", experiment)
AssertionError: 'analysisGroups' not found in [{'codeName': 'EXPT-00000033', 'deleted': False, 'id': 3279, 'ignored': False, 'lsKind': 'default', 'lsLabels': [{'deleted': False, 'id': 97, 'ignored': False, 'labelText': 'Toxicity Screen 1', 'lsKind': 'experiment name', 'lsTransaction': 55, 'lsType': 'name', 'lsTypeAndKind': 'name_experiment name', 'physicallyLabled': False, 'preferred': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'version': 0}], 'lsStates': [{'deleted': False, 'id': 3468, 'ignored': False, 'lsKind': 'data column order', 'lsTransaction': 55, 'lsType': 'metadata', 'lsTypeAndKind': 'metadata_data column order', 'lsValues': [{'codeTypeAndKind': 'null_null', 'deleted': False, 'id': 8552, 'ignored': False, 'lsKind': 'column order', 'lsTransaction': 55, 'lsType': 'numericValue', 'lsTypeAndKind': 'numericValue_column order', 'numericValue': 2, 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'column name', 'codeType': 'data column', 'codeTypeAndKind': 'data column_column name', 'codeValue': 'In vitro Clint', 'deleted': False, 'id': 8555, 'ignored': False, 'lsKind': 'column name', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_column name', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'boolean', 'codeType': 'boolean', 'codeTypeAndKind': 'boolean_boolean', 'codeValue': 'FALSE', 'deleted': False, 'id': 8556, 'ignored': False, 'lsKind': 'hide column', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_hide column', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'boolean', 'codeType': 'boolean', 'codeTypeAndKind': 'boolean_boolean', 'codeValue': 'FALSE', 'deleted': False, 'id': 8557, 'ignored': False, 'lsKind': 'condition column', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_condition column', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'column units', 'codeType': 'data column', 'codeTypeAndKind': 'data column_column units', 'codeValue': 'µL/min/mg protein', 'deleted': False, 'id': 8553, 'ignored': False, 'lsKind': 'column units', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_column units', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'column type', 'codeType': 'data column', 'codeTypeAndKind': 'data column_column type', 'codeValue': 'numericValue', 'deleted': False, 'id': 8554, 'ignored': False, 'lsKind': 'column type', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_column type', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}], 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'version': 0}, {'deleted': False, 'id': 3466, 'ignored': False, 'lsKind': 'data column order', 'lsTransaction': 55, 'lsType': 'metadata', 'lsTypeAndKind': 'metadata_data column order', 'lsValues': [{'codeKind': 'column name', 'codeType': 'data column', 'codeTypeAndKind': 'data column_column name', 'codeValue': 't1/2', 'deleted': False, 'id': 8543, 'ignored': False, 'lsKind': 'column name', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_column name', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'boolean', 'codeType': 'boolean', 'codeTypeAndKind': 'boolean_boolean', 'codeValue': 'FALSE', 'deleted': False, 'id': 8538, 'ignored': False, 'lsKind': 'condition column', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_condition column', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeTypeAndKind': 'null_null', 'deleted': False, 'id': 8542, 'ignored': False, 'lsKind': 'column order', 'lsTransaction': 55, 'lsType': 'numericValue', 'lsTypeAndKind': 'numericValue_column order', 'numericValue': 1, 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'column type', 'codeType': 'data column', 'codeTypeAndKind': 'data column_column type', 'codeValue': 'numericValue', 'deleted': False, 'id': 8540, 'ignored': False, 'lsKind': 'column type', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_column type', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'column units', 'codeType': 'data column', 'codeTypeAndKind': 'data column_column units', 'codeValue': 'min', 'deleted': False, 'id': 8539, 'ignored': False, 'lsKind': 'column units', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_column units', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'boolean', 'codeType': 'boolean', 'codeTypeAndKind': 'boolean_boolean', 'codeValue': 'FALSE', 'deleted': False, 'id': 8541, 'ignored': False, 'lsKind': 'hide column', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_hide column', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'unitTypeAndKind': 'null_null', 'version': 0}], 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'version': 0}, {'deleted': False, 'id': 3467, 'ignored': False, 'lsKind': 'experiment metadata', 'lsTransaction': 55, 'lsType': 'metadata', 'lsTypeAndKind': 'metadata_experiment metadata', 'lsValues': [{'clobValue': '<p>Analysis not yet completed</p>', 'codeTypeAndKind': 'null_null', 'deleted': False, 'id': 8549, 'ignored': True, 'lsKind': 'analysis result html', 'lsTransaction': 55, 'lsType': 'clobValue', 'lsTypeAndKind': 'clobValue_analysis result html', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'unitTypeAndKind': 'null_null', 'version': 1}, {'codeKind': 'status', 'codeOrigin': 'ACAS DDICT', 'codeType': 'experiment', 'codeTypeAndKind': 'experiment_status', 'codeValue': 'approved', 'deleted': False, 'id': 8550, 'ignored': False, 'lsKind': 'experiment status', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_experiment status', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeTypeAndKind': 'null_null', 'codeValue': 'complete', 'deleted': False, 'id': 8562, 'ignored': False, 'lsKind': 'analysis status', 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_analysis status', 'operatorTypeAndKind': 'null_null', 'publicData': False, 'recordedBy': 'default', 'recordedDate': 1744839281288, 'unitTypeAndKind': 'null_null', 'version': 0}, {'clobValue': '<p>Upload completed.</p>\n  \n  <h4>Summary</h4><p>Information:</p>\n                               <ul>\n                               <li>Transaction Id: 55</li><li>Format: Generic</li><li>Protocol: Toxicity</li><li>Experiment: Toxicity Screen 1</li><li>Scientist: bob</li><li>Notebook: Main Experimental Notebook</li><li>Page: Main Experimental Notebook Page 1</li><li>Assay Date: 2025-02-01</li><li>Project: PROJ-00000001</li><li>Rows of Data: 1</li><li>Columns of Data: 2</li><li>Unique Corporate Batch ID\'s: 1</li><li>Experiment Code Name: EXPT-00000033</li>\n                               </ul><div class="bv_openExptInQueryToolSection"></div><p>*Note: there may be a delay before data is visible in Data Viewer</p>', 'codeTypeAndKind': 'null_null', 'deleted': False, 'id': 8563, 'ignored': False, 'lsKind': 'analysis result html', 'lsType': 'clobValue', 'lsTypeAndKind': 'clobValue_analysis result html', 'operatorTypeAndKind': 'null_null', 'publicData': False, 'recordedBy': 'default', 'recordedDate': 1744839281296, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeTypeAndKind': 'null_null', 'deleted': False, 'id': 8544, 'ignored': False, 'lsKind': 'notebook page', 'lsTransaction': 55, 'lsType': 'stringValue', 'lsTypeAndKind': 'stringValue_notebook page', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'stringValue': 'Main Experimental Notebook Page 1', 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeTypeAndKind': 'null_null', 'deleted': False, 'id': 8546, 'ignored': False, 'lsKind': 'notebook', 'lsTransaction': 55, 'lsType': 'stringValue', 'lsTypeAndKind': 'stringValue_notebook', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'stringValue': 'Main Experimental Notebook', 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeTypeAndKind': 'null_null', 'codeValue': 'PROJ-00000001', 'deleted': False, 'id': 8545, 'ignored': False, 'lsKind': 'project', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_project', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeTypeAndKind': 'null_null', 'dateValue': 1738368000000, 'deleted': False, 'id': 8551, 'ignored': False, 'lsKind': 'completion date', 'lsTransaction': 55, 'lsType': 'dateValue', 'lsTypeAndKind': 'dateValue_completion date', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeTypeAndKind': 'null_null', 'comments': 'Toxicity Screen 1.csv', 'deleted': False, 'fileValue': 'experiments/EXPT-00000033/Toxicity Screen 1.csv', 'id': 8561, 'ignored': False, 'lsKind': 'source file', 'lsTransaction': 55, 'lsType': 'fileValue', 'lsTypeAndKind': 'fileValue_source file', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'scientist', 'codeOrigin': 'ACAS authors', 'codeType': 'assay', 'codeTypeAndKind': 'assay_scientist', 'codeValue': 'bob', 'deleted': False, 'id': 8547, 'ignored': False, 'lsKind': 'scientist', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_scientist', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'unitTypeAndKind': 'null_null', 'version': 0}, {'codeKind': 'status', 'codeOrigin': 'ACAS DDICT', 'codeType': 'analysis', 'codeTypeAndKind': 'analysis_status', 'codeValue': 'running', 'deleted': False, 'id': 8548, 'ignored': True, 'lsKind': 'analysis status', 'lsTransaction': 55, 'lsType': 'codeValue', 'lsTypeAndKind': 'codeValue_analysis status', 'operatorTypeAndKind': 'null_null', 'publicData': True, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'unitTypeAndKind': 'null_null', 'version': 1}], 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'version': 0}], 'lsTags': [], 'lsTransaction': 55, 'lsType': 'default', 'lsTypeAndKind': 'default_default', 'modifiedBy': 'bob', 'modifiedDate': 1744839281000, 'protocol': {'codeName': 'PROT-00000008', 'deleted': False, 'id': 3278, 'ignored': False, 'lsKind': 'default', 'lsLabels': [{'deleted': False, 'id': 96, 'ignored': False, 'labelText': 'Toxicity', 'lsKind': 'protocol name', 'lsTransaction': 55, 'lsType': 'name', 'lsTypeAndKind': 'name_protocol name', 'physicallyLabled': False, 'preferred': True, 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'version': 0}], 'lsTransaction': 55, 'lsType': 'default', 'lsTypeAndKind': 'default_default', 'recordedBy': 'bob', 'recordedDate': 1744839280000, 'shortDescription': '', 'version': 0}, 'recordedBy': 'bob', 'recordedDate': 1744839281000, 'shortDescription': '', 'version': 0}]
```

----------------------------------------------------------------------
Ran 109 tests in 131.672s

FAILED (failures=1)

## Explanation 

I accidentally switched to using `get_experiment_by_name` instead of `get_experiment_by_code` prior to publishing the prior PR. `get_experiment_by_name` does not have the arg `full (bool): If true, return the full experiment object`. 

## How Has This Been Tested?

```
$ python -m unittest tests.test_acasclient.TestExperimentLoader.test_021_experiment_with_custom_metadata 
.Successfully deleted all experiments
Successfully deleted all cmpdreg bulk load files
Successfully deleted all projects (except Global)

----------------------------------------------------------------------
Ran 1 test in 2.407s

OK
```