### PR TITLE
ACAS-956 Part 1: Add disabled test for dupe notebook page behavior

### DIFF
--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -4818,6 +4818,82 @@ class TestCmpdReg(BaseAcasClientTest):
         updated_meta_lot = self.client.get_meta_lot(lot_corp_name)
         # Confirm the lotMolWeight has changed
         self.assertNotEqual(original_meta_lot['lot']['lotMolWeight'], updated_meta_lot['lot']['lotMolWeight'], "Updating the salt should change the lot molecular weight")
+    
+    @unittest.skip("ACAS-956: Skip this test for now because uniqueNotebook is false by default")
+    @requires_absent_basic_cmpd_reg_load
+    def test_019_duplicate_notebook_page(self):
+        NB_PAGE_1 = "NB-1234"
+        NB_PAGE_2 = "NB-5678"
+        # Load a 1 compound test file with notebook page hardcoded (success)
+        file = Path(__file__).resolve().parent\
+                .joinpath('test_acasclient', 'test_simple_mol.sdf')
+        mappings = [
+            {
+                "dbProperty": "Lot Notebook Page",
+                "defaultVal": NB_PAGE_1,
+                "required": False,
+                "sdfProperty": None
+            },
+            {
+                "dbProperty": "Lot Chemist",
+                "defaultVal": "bob",
+                "required": True,
+                "sdfProperty": None
+            },
+            {
+                "dbProperty": "Project",
+                "defaultVal": GLOBAL_PROJECT_CODE,
+                "required": True,
+                "sdfProperty": None
+            },
+            {
+                "dbProperty": "Parent Stereo Category",
+                "defaultVal": STEREO_CATEGORY,
+                "required": True,
+                "sdfProperty": None
+            },
+        ]
+        response = self.client.register_sdf(file, "bob", mappings, dry_run=False)
+        # Load the same again in dryrun and confirm we get an error about duplicate notebook page
+        response = self.client.register_sdf(file, "bob", mappings, dry_run=True)
+        self.assertGreater(len(response['results']), 0, "Expected error results for duplicate lot")
+        err_result = response['results'][0]
+        self.assertEqual(err_result['level'], 'error', "Expected an error level result for duplicate notebook page")
+        self.assertEqual(err_result['message'], f'Lot notebook page "{NB_PAGE_1}" is already in use. Please use a unique notebook page.', "Expected error message to mention the duplicated notebook page.")
+        # Dryrun Load a 2 compound file with a 2nd nb page hardcoded. Confirm we get back an error that the nb page is duplicated within the same file.
+        file = Path(__file__).resolve().parent\
+                .joinpath('test_acasclient', 'test_012_register_sdf.sdf')
+        mappings = [
+            {
+                "dbProperty": "Lot Notebook Page",
+                "defaultVal": NB_PAGE_2,
+                "required": False,
+                "sdfProperty": None
+            },
+            {
+                "dbProperty": "Lot Chemist",
+                "defaultVal": "bob",
+                "required": True,
+                "sdfProperty": None
+            },
+            {
+                "dbProperty": "Project",
+                "defaultVal": GLOBAL_PROJECT_CODE,
+                "required": True,
+                "sdfProperty": None
+            },
+            {
+                "dbProperty": "Parent Stereo Category",
+                "defaultVal": STEREO_CATEGORY,
+                "required": True,
+                "sdfProperty": None
+            },
+        ]
+        response = self.client.register_sdf(file, "bob", mappings, dry_run=True)
+        self.assertGreater(len(response['results']), 0, "Expected error results for duplicate notebook page within file")
+        err_result = response['results'][0]
+        self.assertEqual(err_result['level'], 'error', "Expected an error level result for duplicate notebook page within file")
+        self.assertEqual(err_result['message'], f'Lot notebook page "{NB_PAGE_2}" is duplicated within the same bulk load file. Please use a unique notebook page.', "Expected error message to indicate duplicate notebook page within file")
 
 class TestExperimentLoader(BaseAcasClientTest):
     """Tests for `Experiment Loading`."""

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -4856,10 +4856,11 @@ class TestCmpdReg(BaseAcasClientTest):
         response = self.client.register_sdf(file, "bob", mappings, dry_run=False)
         # Load the same again in dryrun and confirm we get an error about duplicate notebook page
         response = self.client.register_sdf(file, "bob", mappings, dry_run=True)
-        self.assertGreater(len(response['results']), 0, "Expected error results for duplicate lot")
-        err_result = response['results'][0]
-        self.assertEqual(err_result['level'], 'error', "Expected an error level result for duplicate notebook page")
-        self.assertEqual(err_result['message'], f'Lot notebook page "{NB_PAGE_1}" is already in use. Please use a unique notebook page.', "Expected error message to mention the duplicated notebook page.")
+        err_results = [res for res in response.get('results', []) if res.get('level') == 'error']
+        self.assertGreater(len(err_results), 0, "Expected an error level result for duplicate notebook page")
+        # Assert at least one error message mentions the duplicated notebook page
+        err_result = next((res for res in err_results if NB_PAGE_1 in res.get('message', '')), None)
+        self.assertIsNotNone(err_result, "Expected an error message to mention the duplicated notebook page.")
         # Dryrun Load a 2 compound file with a 2nd nb page hardcoded. Confirm we get back an error that the nb page is duplicated within the same file.
         file = Path(__file__).resolve().parent\
                 .joinpath('test_acasclient', 'test_012_register_sdf.sdf')
@@ -4891,9 +4892,13 @@ class TestCmpdReg(BaseAcasClientTest):
         ]
         response = self.client.register_sdf(file, "bob", mappings, dry_run=True)
         self.assertGreater(len(response['results']), 0, "Expected error results for duplicate notebook page within file")
-        err_result = response['results'][0]
-        self.assertEqual(err_result['level'], 'error', "Expected an error level result for duplicate notebook page within file")
-        self.assertEqual(err_result['message'], f'Lot notebook page "{NB_PAGE_2}" is duplicated within the same bulk load file. Please use a unique notebook page.', "Expected error message to indicate duplicate notebook page within file")
+        err_results = [res for res in response.get('results', []) if res.get('level') == 'error']
+        self.assertGreater(len(err_results), 0, "Expected an error level result for duplicate notebook page")
+        # Assert at least one error message mentions the duplicated notebook page
+        err_result = next((res for res in err_results if NB_PAGE_2 in res.get('message', '')), None)
+        self.assertIsNotNone(err_result, "Expected an error message to mention the duplicated notebook page.")
+        self.assertNotEqual(len(err_results), 0, "Expected at least one error result for duplicate notebook page within file")
+        self.assertIn("within the same bulk load file", err_results[0]['message'], "Expected error message to mention that the duplicate notebook page is within the same bulk load file")
 
 class TestExperimentLoader(BaseAcasClientTest):
     """Tests for `Experiment Loading`."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The bug ACAS-956 describes buggy behavior in bulk loader when the `uniqueNotebook` config is `true`. I've added a test covering the fixed behavior from https://github.com/mcneilco/acas-roo-server/pull/507
However since `uniqueNotebook=false` in our default configs, I've marked this test as skipped.

I have a plan for enabling automated testing of alternative config states which I'll be posting in subsequent PRs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
- Confirmed the test is skipped 
```
(.venv) ➜  acasclient git:(ACAS-956-1) ✗ python -m unittest -v tests.test_acasclient.TestCmpdReg.test_019_duplicate_notebook_page
test_019_duplicate_notebook_page (tests.test_acasclient.TestCmpdReg) ... skipped 'ACAS-956: Skip this test for now because uniqueNotebook is false by default'
Successfully deleted all experiments
Successfully deleted all cmpdreg bulk load files
Successfully deleted all salts
Successfully deleted all projects (except Global)

----------------------------------------------------------------------
Ran 1 test in 1.785s

OK (skipped=1)
```
- Commented out the skip line (running against local docker compose w/ `uniqueNotebook=true`) and confirmed the test passes
```
.venv) ➜  acasclient git:(ACAS-956-1) ✗ python -m unittest -v tests.test_acasclient.TestCmpdReg.test_019_duplicate_notebook_page
test_019_duplicate_notebook_page (tests.test_acasclient.TestCmpdReg) ... ok
Successfully deleted all experiments
Successfully deleted all cmpdreg bulk load files
Successfully deleted all salts
Successfully deleted all projects (except Global)

----------------------------------------------------------------------
Ran 1 test in 4.997s

OK
```