### PR TITLE
ACAS-956 extension: Add pytest and config-aware checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,13 @@ lint: ## check style with flake8
 	flake8 acasclient tests
 
 test: ## run tests quickly with the default Python
-	python setup.py test
+	python -m pytest
 
 test-all: ## run tests on every Python version with tox
 	tox
 
 coverage: ## check code coverage quickly with the default Python
-	coverage run --source acasclient setup.py test
+	coverage run -m pytest
 	coverage report -m
 	coverage html
 	$(BROWSER) htmlcov/index.html

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,5 @@
-pip==25.3
 bump2version==0.5.11
 wheel==0.38.1
-watchdog==0.9.0
 flake8==3.7.8
-tox==3.14.0
 coverage==4.5.4
-Sphinx==1.8.5
-twine==1.14.0
-decorator==5.1.1
-pandas==1.4.3
+pytest

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = ['requests', 'pandas', 'six', 'decorator', 'openpyxl', 'xlrd'],
 
 setup_requirements = [ ]
 
-test_requirements = [ ]
+test_requirements = ['pytest']
 
 setup(
     author="Brian Bolt",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+"""
+Pytest configuration for acasclient tests.
+
+Provides:
+- requires_config marker for config-dependent tests
+- Client config fetching from ACAS /conf/conf.js endpoint
+"""
+
+import json
+import pytest
+import requests
+
+
+# Cached config - fetched once per session
+_cached_config = None
+
+
+def get_nested_value(d, path):
+    """
+    Get a nested value from a dictionary using dot notation.
+
+    Args:
+        d: Dictionary to search
+        path: Dot-separated path (e.g., 'cmpdreg.serverSettings.uniqueNotebook')
+
+    Returns:
+        The value at the path, or None if not found
+    """
+    keys = path.split('.')
+    current = d
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+        if current is None:
+            return None
+    return current
+
+
+def get_client_config(base_url="http://localhost:3000"):
+    """
+    Fetch client config from ACAS /conf/conf.js endpoint.
+
+    Cached after first call. Returns empty dict on error (tests will skip).
+    """
+    global _cached_config
+    if _cached_config is None:
+        try:
+            response = requests.get(f"{base_url}/conf/conf.js", timeout=5)
+            response.raise_for_status()
+            js_content = response.text
+            # Strip "window.conf=" prefix and parse JSON
+            json_str = js_content.replace("window.conf=", "", 1).rstrip(";")
+            _cached_config = json.loads(json_str)
+        except Exception as e:
+            print(f"Warning: Could not fetch ACAS config from {base_url}/conf/conf.js: {e}")
+            print("Tests requiring specific config will be skipped.")
+            _cached_config = {}
+    return _cached_config
+
+
+def pytest_configure(config):
+    """Register the requires_config marker."""
+    config.addinivalue_line(
+        "markers",
+        "requires_config(**kwargs): skip test unless ACAS config matches requirements. "
+        "Use dot notation for nested keys, e.g., "
+        "@pytest.mark.requires_config(**{'cmpdreg.serverSettings.uniqueNotebook': True})"
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    """Skip tests whose config requirements are not met."""
+    for marker in item.iter_markers(name="requires_config"):
+        config = get_client_config()
+        for path, expected in marker.kwargs.items():
+            actual = get_nested_value(config, path)
+            if actual != expected:
+                pytest.skip(f"Requires {path}={expected}, got {actual}")

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -4,6 +4,7 @@
 
 from functools import wraps
 import unittest
+import pytest
 from acasclient import acasclient
 from pathlib import Path
 import tempfile
@@ -4819,7 +4820,7 @@ class TestCmpdReg(BaseAcasClientTest):
         # Confirm the lotMolWeight has changed
         self.assertNotEqual(original_meta_lot['lot']['lotMolWeight'], updated_meta_lot['lot']['lotMolWeight'], "Updating the salt should change the lot molecular weight")
     
-    @unittest.skip("ACAS-956: Skip this test for now because uniqueNotebook is false by default")
+    @pytest.mark.requires_config(**{'cmpdreg.serverSettings.uniqueNotebook': True})
     @requires_absent_basic_cmpd_reg_load
     def test_019_duplicate_notebook_page(self):
         NB_PAGE_1 = "NB-1234"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
A longstanding issue with our automated test coverage is that we can only test our default configs. This is a heavily Claude-fueled attempt at a solution. It adds:
- Utility to fetch `client` configs only from where they're already exposed by acas and parse them
- Added pytest as a testing dependency
- Added custom pytest decorator to mark tests as requiring certain configs to run, otherwise they're skipped

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
- Confirmed the test runs when local instance is running with `uniqueNotebook=true`
```
(.venv) ➜  acasclient git:(ACAS-956-3) pytest tests/test_acasclient.py::TestCmpdReg::test_019_duplicate_notebook_page
============================================== test session starts ===============================================
platform darwin -- Python 3.10.20, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/frost/Projects/ACAS/acasclient
collected 1 item                                                                                                 

tests/test_acasclient.py .                                                                                 [100%]

=============================================== 1 passed in 5.12s ================================================
```
- Confirmed the test skips when local instance has it false
```
(.venv) ➜  acasclient git:(ACAS-956-3) pytest tests/test_acasclient.py::TestCmpdReg::test_019_duplicate_notebook_page
============================================== test session starts ===============================================
platform darwin -- Python 3.10.20, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/frost/Projects/ACAS/acasclient
collected 1 item                                                                                                 

tests/test_acasclient.py s                                                                                 [100%]

=============================================== 1 skipped in 0.47s ===============================================
```

## Topics for Discussion
### client-only configs
The mechanism by which I'm fetching configs is limited to only client-side. We have many potential test cases for server-side configs, but want to avoid the security risk of exposing server-side configs via the frontend.
Some options I considered:
- Adding a special environment variable such as (`TEST_MODE`) and adding a new node API route that exposes the full configs only when that's true, then using that
- Having the pytest helper run `docker compose exec` to fetch the config file contents

### Managing "alternative config collections"
I have a POC working with docker compose override files to override config-related env vars. These could serve as small "libraries" of alternate configs to run tests with, but they would be checked into the `acas` repo and thus separated somewhat from the test suite here.

`docker-compose.test-unique-notebook.yml`
```
version: '2'

# Docker Compose override for testing with uniqueNotebook=true
#
# Usage:
#   docker-compose -f docker-compose.yml -f docker-compose.test-unique-notebook.yml up -d
#
# This enables the compound registration setting that enforces unique notebook pages
# across all lots in the database.

services:
  acas:
    environment:
      # Override the uniqueNotebook setting to true
      - ACAS_CLIENT_CMPDREG_SERVERSETTINGS_UNIQUENOTEBOOK=true
```

Then running the CI tests in a matrix like this: https://github.com/mcneilco/acasclient/compare/ACAS-956-2...ACAS-956-3?expand=1