### PR TITLE
ACAS-928: Cover additional special characters in search test

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -15,8 +15,18 @@ import base64
 import hashlib
 from io import StringIO, IOBase
 from typing import Dict, List, Tuple
-from urllib.parse import quote
+from urllib.parse import quote as _stdlib_quote
 from contextlib import contextmanager
+
+
+def quote_path_segment(s):
+    """Percent-encode a string for use in a URL path segment.
+
+    Like urllib.parse.quote(s, safe=''), but also encodes '.' which quote()
+    considers unreserved. A bare '.' or '..' in a path segment is treated as
+    a relative-path reference and gets normalized away by HTTP stacks.
+    """
+    return _stdlib_quote(s, safe='').replace('.', '%2E')
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -994,7 +1004,7 @@ class client():
         Returns: Returns an array of protocols
         """
         resp = self.session.get("{}/api/protocols/genericSearch/{}"
-                                .format(self.url, quote(search_term, safe='')))
+                                .format(self.url, quote_path_segment(search_term)))
         resp.raise_for_status()
         return resp.json()
 
@@ -1009,7 +1019,7 @@ class client():
         Returns: Returns an array of experiments
         """
         resp = self.session.get("{}/api/getProtocolByLabel/{}"
-                                .format(self.url, quote(label, safe='')))
+                                .format(self.url, quote_path_segment(label)))
         resp.raise_for_status()
         return resp.json()
     
@@ -1135,7 +1145,7 @@ class client():
         """
 
         resp = self.session.get("{}/api/experiments/experimentName/{}".
-                                format(self.url, quote(experiment_name, safe='')))
+                                format(self.url, quote_path_segment(experiment_name)))
         if resp.status_code == 500:
             return None
         resp.raise_for_status()
@@ -1436,7 +1446,7 @@ en array of protocols
             params['projectCodes'] = ','.join(project_codes)
 
         resp = self.session.get("{}/api/experiments/genericSearch/{}/"
-                                .format(self.url, quote(query, safe='')),
+                                .format(self.url, quote_path_segment(query)),
                                 params=params)
 
         resp.raise_for_status()

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3009,14 +3009,17 @@ class TestAcasclient(BaseAcasClientTest):
     @requires_basic_cmpd_reg_load
     def test_057_get_protocol_expt_special_characters_in_names(self):
         """Test getting protocols and experiments with special characters in their names."""
-        protocol_name = "test/protocol.name !@#$%^&*(special/chars)"
-        experiment_name = "test/experiment.name !@#$%^&*(special/chars)"
+        protocol_name = "test/protocol.name !@#[%]$%^&*(special/chars)"
+        experiment_name = "test/experiment.name !@#[%]$%^&*(special/chars)"
         file_to_upload = get_basic_experiment_load_file(self.tempdir, protocol_name=protocol_name, experiment_name=experiment_name)
         response = self.client.\
             experiment_loader(file_to_upload, "bob", False)
         # Search for the protocol by name
         res = self.client.protocol_search(protocol_name)
         self.assertEqual(len(res), 1)
+        # Search for the protocol by substring
+        res = self.client.protocol_search("[")
+        self.assertEqual(len(res), 1, "Expected to find protocol when searching with partial special characters")
         # Get the protocol by name
         res = self.client.get_protocols_by_label(protocol_name)
         self.assertEqual(len(res), 1)
@@ -3025,6 +3028,10 @@ class TestAcasclient(BaseAcasClientTest):
         # Filter out the ignored = True experiments
         res = [x for x in res if x['ignored'] is False]
         self.assertEqual(len(res), 1)
+         # Search for the protocol by substring
+        res = self.client.experiment_search("[")
+        res = [x for x in res if x['ignored'] is False]
+        self.assertEqual(len(res), 1, "Expected to find experiment when searching with partial special characters")
         # Get the experiment by name
         expt = self.client.get_experiment_by_name(experiment_name)
         res = [x for x in res if x['ignored'] is False]

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3014,13 +3014,16 @@ class TestAcasclient(BaseAcasClientTest):
         file_to_upload = get_basic_experiment_load_file(self.tempdir, protocol_name=protocol_name, experiment_name=experiment_name)
         response = self.client.\
             experiment_loader(file_to_upload, "bob", False)
+        expt_code = response['results']['experimentCode']
+        protocol_code = self.client.get_experiment_by_code(expt_code)['protocol']['codeName']
         # Search for the protocol by name
         res = self.client.protocol_search(protocol_name)
         self.assertEqual(len(res), 1)
         # Search for the protocol by substring
         for char in protocol_name:
             res = self.client.protocol_search(char)
-            self.assertEqual(len(res), 1, f"Expected to find protocol when searching with any substring, but failed with {char}")
+            match = [x for x in res if x['codeName'] == protocol_code]
+            self.assertEqual(len(match), 1, f"Expected to find protocol when searching with any substring, but failed with {char}")
         # Get the protocol by name
         res = self.client.get_protocols_by_label(protocol_name)
         self.assertEqual(len(res), 1)
@@ -3033,7 +3036,8 @@ class TestAcasclient(BaseAcasClientTest):
         for char in experiment_name:
             res = self.client.experiment_search(char)
             res = [x for x in res if x['ignored'] is False]
-            self.assertEqual(len(res), 1, f"Expected to find experiment when searching with any substring, but failed with {char}")
+            match = [x for x in res if x['codeName'] == expt_code]
+            self.assertEqual(len(match), 1, f"Expected to find experiment when searching with any substring, but failed with {char}")
         # Get the experiment by name
         expt = self.client.get_experiment_by_name(experiment_name)
         res = [x for x in res if x['ignored'] is False]

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3018,8 +3018,9 @@ class TestAcasclient(BaseAcasClientTest):
         res = self.client.protocol_search(protocol_name)
         self.assertEqual(len(res), 1)
         # Search for the protocol by substring
-        res = self.client.protocol_search("[")
-        self.assertEqual(len(res), 1, "Expected to find protocol when searching with partial special characters")
+        for char in protocol_name:
+            res = self.client.protocol_search(char)
+            self.assertEqual(len(res), 1, f"Expected to find protocol when searching with any substring, but failed with {char}")
         # Get the protocol by name
         res = self.client.get_protocols_by_label(protocol_name)
         self.assertEqual(len(res), 1)
@@ -3028,10 +3029,11 @@ class TestAcasclient(BaseAcasClientTest):
         # Filter out the ignored = True experiments
         res = [x for x in res if x['ignored'] is False]
         self.assertEqual(len(res), 1)
-         # Search for the protocol by substring
-        res = self.client.experiment_search("[")
-        res = [x for x in res if x['ignored'] is False]
-        self.assertEqual(len(res), 1, "Expected to find experiment when searching with partial special characters")
+        # Search for the experiment by substring
+        for char in experiment_name:
+            res = self.client.experiment_search(char)
+            res = [x for x in res if x['ignored'] is False]
+            self.assertEqual(len(res), 1, f"Expected to find experiment when searching with any substring, but failed with {char}")
         # Get the experiment by name
         expt = self.client.get_experiment_by_name(experiment_name)
         res = [x for x in res if x['ignored'] is False]

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -3009,8 +3009,10 @@ class TestAcasclient(BaseAcasClientTest):
     @requires_basic_cmpd_reg_load
     def test_057_get_protocol_expt_special_characters_in_names(self):
         """Test getting protocols and experiments with special characters in their names."""
-        protocol_name = "test/protocol.name !@#[%]$%^&*(special/chars)"
-        experiment_name = "test/experiment.name !@#[%]$%^&*(special/chars)"
+        # Define special characters to test - each character unique to avoid redundant searches
+        special_chars = "/. !@#[]%$^&*()"
+        protocol_name = f"test_protocol{special_chars}name"
+        experiment_name = f"test_experiment{special_chars}name"
         file_to_upload = get_basic_experiment_load_file(self.tempdir, protocol_name=protocol_name, experiment_name=experiment_name)
         response = self.client.\
             experiment_loader(file_to_upload, "bob", False)
@@ -3019,11 +3021,11 @@ class TestAcasclient(BaseAcasClientTest):
         # Search for the protocol by name
         res = self.client.protocol_search(protocol_name)
         self.assertEqual(len(res), 1)
-        # Search for the protocol by substring
-        for char in protocol_name:
+        # Search for the protocol by each special character
+        for char in special_chars:
             res = self.client.protocol_search(char)
             match = [x for x in res if x['codeName'] == protocol_code]
-            self.assertEqual(len(match), 1, f"Expected to find protocol when searching with any substring, but failed with {char}")
+            self.assertEqual(len(match), 1, f"Expected to find protocol when searching with special char, but failed with '{char}'")
         # Get the protocol by name
         res = self.client.get_protocols_by_label(protocol_name)
         self.assertEqual(len(res), 1)
@@ -3032,12 +3034,12 @@ class TestAcasclient(BaseAcasClientTest):
         # Filter out the ignored = True experiments
         res = [x for x in res if x['ignored'] is False]
         self.assertEqual(len(res), 1)
-        # Search for the experiment by substring
-        for char in experiment_name:
+        # Search for the experiment by each special character
+        for char in special_chars:
             res = self.client.experiment_search(char)
             res = [x for x in res if x['ignored'] is False]
             match = [x for x in res if x['codeName'] == expt_code]
-            self.assertEqual(len(match), 1, f"Expected to find experiment when searching with any substring, but failed with {char}")
+            self.assertEqual(len(match), 1, f"Expected to find experiment when searching with special char, but failed with '{char}'")
         # Get the experiment by name
         expt = self.client.get_experiment_by_name(experiment_name)
         res = [x for x in res if x['ignored'] is False]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Original fix missed some locations which caused certain special characters to not work. Added a test that covers them to confirm the fix.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
```
(.venv) ➜  acasclient git:(release/2026.2.x) ✗ python -m unittest -v tests.test_acasclient.TestAcasclient.test_057_get_protocol_expt_special_characters_in_names
test_057_get_protocol_expt_special_characters_in_names (tests.test_acasclient.TestAcasclient)
Test getting protocols and experiments with special characters in their names. ... ok
Successfully deleted all experiments
Successfully deleted all cmpdreg bulk load files
Successfully deleted all salts
Successfully deleted all projects (except Global)

----------------------------------------------------------------------
Ran 1 test in 5.548s

OK
```