### PR TITLE
ACAS-923: Expect 404 for missing protocol experiments

### DIFF
--- a/acasclient/acasclient.py
+++ b/acasclient/acasclient.py
@@ -1117,10 +1117,7 @@ class client():
         """
         resp = self.session.get("{}/api/experiments/protocolCodename/{}".
                                 format(self.url, protocol_code))
-        if resp.status_code == 500:
-            return None
-        else:
-            resp.raise_for_status()
+        resp.raise_for_status()
         return resp.json()
 
     def get_experiment_by_name(self, experiment_name):

--- a/tests/test_acasclient.py
+++ b/tests/test_acasclient.py
@@ -1505,9 +1505,9 @@ class TestAcasclient(BaseAcasClientTest):
 
         self.assertEqual(experiments[0]["lsLabels"][0]["labelText"],
                          experiment["lsLabels"][0]["labelText"])
-        experiments = self.client.\
-            get_experiments_by_protocol_code("FAKECODE")
-        self.assertIsNone(experiments)
+        with self.assertRaises(requests.HTTPError) as context:
+            self.client.get_experiments_by_protocol_code("FAKECODE")
+        self.assertIn('404 Client Error: Not Found', str(context.exception))
 
         # Verify project restrictions work
         # Create a restricted project 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While adding retries to acasclient I ran into an odd API behavior where non-existent protocol codes would return 500 errors and terminate wrapper scripts that called acasclient. I papered over it by adding
```
    if resp.status_code == 500:
            return None
 ```
however this obfuscated the difference between legitimate "not found" and true 500 server errors like those caused by Java OOM.

This is part 3 of a 3 PR fix:
- https://github.com/mcneilco/acas-roo-server/pull/518 fixes Roo error throwing to yield a 404
- https://github.com/mcneilco/acas/pull/1248 fixes Node to pass through the 404 rather than converting it to a 500
- This acasclient test & removal of workaround that was converting 500s to `None`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
- Ran this acasclient test against local docker compose that had the other fixes live